### PR TITLE
Several small patches

### DIFF
--- a/zuora/rest_wrapper/account_manager.py
+++ b/zuora/rest_wrapper/account_manager.py
@@ -11,44 +11,44 @@ class AccountManager(RequestBase):
     @rest_client_reconnect
     def create_account(self, **kwargs):
         fullUrl = self.zuora_config.base_url + 'accounts'
-    
+
         if kwargs:
             data = json.dumps(kwargs)
         else:
             # No parameters were passed in
             return None
-    
+
         response = requests.post(fullUrl, data=data,
                                  headers=self.zuora_config.headers,
                                  verify=False)
         return self.get_json(response)
-    
+
     @rest_client_reconnect
     def get_account_summary(self, accountKey):
         fullUrl = self.zuora_config.base_url + 'accounts/' + accountKey + \
                   '/summary'
-    
+
         response = requests.get(fullUrl, headers=self.zuora_config.headers,
                                 verify=False)
         return self.get_json(response)
-    
+
     @rest_client_reconnect
     def get_account(self, accountKey):
-        fullUrl = self.zuora_config.baseUrl + 'accounts/' + accountKey
-    
+        fullUrl = self.zuora_config.base_url + 'accounts/' + accountKey
+
         response = requests.get(fullUrl, headers=self.zuora_config.headers,
                                 verify=False)
         return self.get_json(response)
-    
+
     @rest_client_reconnect
     def update_account(self, accountKey, **kwargs):
-        fullUrl = self.zuora_config.baseUrl + 'accounts/' + accountKey
-    
+        fullUrl = self.zuora_config.base_url + 'accounts/' + accountKey
+
         if kwargs:
             data = json.dumps(kwargs)
         else:
             data = None
-    
+
         response = requests.put(fullUrl, data=data,
                                 headers=self.zuora_config.headers,
                                 verify=False)

--- a/zuora/rest_wrapper/subscription_manager.py
+++ b/zuora/rest_wrapper/subscription_manager.py
@@ -14,19 +14,23 @@ class SubscriptionManager(RequestBase):
         fullUrl = self.zuora_config.base_url + 'subscriptions/accounts/' + \
                   accountKey
         data = {'pageSize': pageSize}
-    
+
         response = requests.get(fullUrl, params=data,
                                 headers=self.zuora_config.headers,
                                 verify=False)
         return self.get_json(response)
 
     @rest_client_reconnect
-    def get_subscriptions_by_key(self, subsKey):
+    def get_subscription_by_key(self, subsKey):
         fullUrl = self.zuora_config.base_url + 'subscriptions/' + subsKey
         response = requests.get(fullUrl, headers=self.zuora_config.headers,
                                 verify=False)
         return self.get_json(response)
-    
+
+    @rest_client_reconnect
+    def get_subscriptions_by_key(self, subsKey):
+        return self.get_subscription_by_key(subsKey)
+
     @rest_client_reconnect
     def renew_subscription(self, subsKey,
                            jsonParams={'invoiceCollect': False}):
@@ -38,7 +42,7 @@ class SubscriptionManager(RequestBase):
                                 verify=False
         )
         return self.get_json(response)
-    
+
     @rest_client_reconnect
     def cancel_subscription(self, subsKey, jsonParams={}):
         jsonParams.setdefault('cancellationPolicy',
@@ -51,7 +55,7 @@ class SubscriptionManager(RequestBase):
                                 headers=self.zuora_config.headers,
                                 verify=False)
         return self.get_json(response)
-    
+
     @rest_client_reconnect
     def preview_subscription(self, jsonParams):
         fullUrl = self.zuora_config.base_url + 'subscriptions/preview'
@@ -60,7 +64,7 @@ class SubscriptionManager(RequestBase):
                                  headers=self.zuora_config.headers,
                                  verify=False)
         return self.get_json(response)
-    
+
     @rest_client_reconnect
     def create_subscription(self, jsonParams):
         fullUrl = self.zuora_config.base_url + 'subscriptions'
@@ -69,7 +73,7 @@ class SubscriptionManager(RequestBase):
                                  headers=self.zuora_config.headers,
                                  verify=False)
         return self.get_json(response)
-    
+
     @rest_client_reconnect
     def update_subscription(self, subsKey, jsonParams):
         fullUrl = self.zuora_config.base_url + 'subscriptions/' + subsKey
@@ -78,4 +82,4 @@ class SubscriptionManager(RequestBase):
                                 headers=self.zuora_config.headers,
                                 verify=False)
         return self.get_json(response)
-        
+

--- a/zuora/zuora.a.64.0.dev.wsdl
+++ b/zuora/zuora.a.64.0.dev.wsdl
@@ -1,0 +1,1833 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright Zuora, Inc. 2007 - 2010 All Rights Reserved. -->
+
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" 
+	xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" 
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+	xmlns:zns="http://api.zuora.com/" 
+	xmlns:ons="http://object.api.zuora.com/"
+	xmlns:fns="http://fault.api.zuora.com/"
+	targetNamespace="http://api.zuora.com/">
+	<types>
+		<schema attributeFormDefault="qualified" elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://object.api.zuora.com/">
+		    <import namespace="http://api.zuora.com/" />
+            <complexType name="zObject">
+				<sequence>
+					<element minOccurs="0" maxOccurs="unbounded" name="fieldsToNull" nillable="true" type="string" />
+					<element minOccurs="0" maxOccurs="1" name="Id" nillable="true" type="zns:ID" />
+				</sequence>
+			</complexType>
+			
+	
+	<complexType name="AccountingCode">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+					       	<element minOccurs="0" name="Category" nillable="true" type="string" />
+					       	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+					       	<element minOccurs="0" name="GLAccountName" nillable="true" type="string"   />
+					       	<element minOccurs="0" name="GLAccountNumber" nillable="true" type="string"   />
+					        <element minOccurs="0" name="Name" nillable="false" type="string" />
+					       	<element minOccurs="0" name="Notes" nillable="true" type="string" />
+					       	<element minOccurs="0" name="Status" nillable="true" type="string" />
+					       	<element minOccurs="0" name="Type" nillable="false" type="string" />
+					       	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+						</sequence>
+					</extension>
+				</complexContent>
+		</complexType>
+	
+	<complexType name="AccountingPeriod">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+					       	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+					       	<element minOccurs="0" name="EndDate" nillable="true" type="dateTime" />
+					       	<element minOccurs="0" name="FiscalYear" nillable="true" type="int" />
+					        <element minOccurs="0" name="Name" nillable="true" type="string" />
+					       	<element minOccurs="0" name="Notes" nillable="true" type="string" />
+					        <element minOccurs="0" name="StartDate" nillable="true" type="dateTime" />
+					       	<element minOccurs="0" name="Status" nillable="true" type="string" />
+					       	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+						</sequence>
+					</extension>
+				</complexContent>
+		</complexType>
+			<complexType name="Account" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="AdditionalEmailAddresses" nillable="true" type="string" />
+							<element minOccurs="0" name="AllowInvoiceEdit" nillable="true" type="boolean"  />
+							<element minOccurs="0" name="AutoPay" nillable="true" type="boolean" />
+							<element minOccurs="0" name="Balance" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Batch" nillable="true" type="string" />
+							<element minOccurs="0" name="BcdSettingOption" nillable="true" type="string" />
+							<element minOccurs="0" name="BillCycleDay" type="int" />
+							<element minOccurs="0" name="BillToId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="CommunicationProfileId" nillable="true" type="zns:ID" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="CrmId" nillable="true" type="string" />
+							<element minOccurs="0" name="Currency" nillable="true" type="string" />
+							<element minOccurs="0" name="CustomerServiceRepName" nillable="true" type="string" />
+							<element minOccurs="0" name="DefaultPaymentMethodId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="InvoiceDeliveryPrefsEmail" nillable="true" type="boolean" />
+							<element minOccurs="0" name="InvoiceDeliveryPrefsPrint" nillable="true" type="boolean" />
+							<element minOccurs="0" name="InvoiceTemplateId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="LastInvoiceDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="Notes" nillable="true" type="string" />
+							<element minOccurs="0" name="PaymentGateway" nillable="true" type="string"  />
+							<element minOccurs="0" name="PaymentTerm" nillable="true" type="string" /><!-- user-defined enum -->
+							<element minOccurs="0" name="PurchaseOrderNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="SalesRepName" nillable="true" type="string" />
+							<element minOccurs="0" name="SoldToId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			
+<complexType name="InvoiceItemAdjustment" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="AdjustmentDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="AdjustmentNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="Amount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="CancelledById" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="CancelledDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Comment" nillable="true" type="string" />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="CustomerName" nillable="true" type="string" />
+							<element minOccurs="0" name="CustomerNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="InvoiceItemName" nillable="true" type="string" />
+							<element minOccurs="0" name="InvoiceNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="ReasonCode" nillable="true" type="string" />
+							<element minOccurs="0" name="ReferenceId" nillable="true" type="string" />
+							<element minOccurs="0" name="ServiceEndDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ServiceStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="SourceId" nillable="true" type="string" />
+							<element minOccurs="0" name="SourceType" nillable="true" type="string" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="TransferredToAccounting" nillable="true" type="string" />
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>	
+
+			<complexType name="Amendment">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AutoRenew" nillable="true" type="boolean"  />
+							<element minOccurs="0" name="Code" nillable="true" type="string" />
+							<element minOccurs="0" name="ContractEffectiveDate" nillable="true" type="dateTime" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+               				<element minOccurs="0" name="CustomerAcceptanceDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="EffectiveDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="InitialTerm" nillable="true" type="long" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="RatePlanData" nillable="true" type="zns:RatePlanData" />
+               				<element minOccurs="0" name="RenewalSetting" nillable="true" type="string" />
+							<element minOccurs="0" name="RenewalTerm" nillable="true" type="long" />
+							<element minOccurs="0" name="ServiceActivationDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="TermStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TermType" nillable="true" type="string"  />
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Contact">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="Address1" nillable="true" type="string" />
+							<element minOccurs="0" name="Address2" nillable="true" type="string" />
+							<element minOccurs="0" name="City" nillable="true" type="string" />
+							<element minOccurs="0" name="Country" nillable="true" type="string" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Fax" nillable="true" type="string" />
+							<element minOccurs="0" name="FirstName" nillable="true" type="string" />
+							<element minOccurs="0" name="HomePhone" nillable="true" type="string" />
+							<element minOccurs="0" name="LastName" nillable="true" type="string" />
+							<element minOccurs="0" name="MobilePhone" nillable="true" type="string" />
+							<element minOccurs="0" name="NickName" nillable="true" type="string" />
+							<element minOccurs="0" name="OtherPhone" nillable="true" type="string" />
+							<element minOccurs="0" name="OtherPhoneType" nillable="true" type="string" />
+							<element minOccurs="0" name="PersonalEmail" nillable="true" type="string" />
+							<element minOccurs="0" name="PostalCode" nillable="true" type="string" />
+							<element minOccurs="0" name="State" nillable="true" type="string" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+              				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="WorkEmail" nillable="true" type="string" />
+							<element minOccurs="0" name="WorkPhone" nillable="true" type="string" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Invoice" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AdjustmentAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Amount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Balance" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Body" nillable="true" type="string" />
+							<element minOccurs="0" name="Comments" nillable="true" type="string" />
+							<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="DueDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="IncludesOneTime" nillable="true" type="boolean" />
+							<element minOccurs="0" name="IncludesRecurring" nillable="true" type="boolean" />
+							<element minOccurs="0" name="IncludesUsage" nillable="true" type="boolean" />
+							<element minOccurs="0" name="InvoiceDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="InvoiceNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="LastEmailSentDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="PaymentAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="PostedBy" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="PostedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="RefundAmount" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="RegenerateInvoicePDF" nillable="true" type="boolean"  />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="TargetDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TransferredToAccounting" nillable="true" type="string" />
+							<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Refund" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="Amount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="CancelledOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Comment" nillable="true" type="string" />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Gateway" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayOptionData" nillable="true" type="zns:GatewayOptionData" />
+							<element minOccurs="0" name="GatewayResponse" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayResponseCode" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayState" nillable="true" type="string" />
+							<element minOccurs="0" name="MarkedForSubmissionOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="MethodType" nillable="true" type="string" />
+							<element minOccurs="0" name="PaymentId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="PaymentMethodId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="PaymentMethodSnapshotId" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="ReasonCode" nillable="true" type="string" />
+							<element minOccurs="0" name="ReferenceID" nillable="true" type="string" />
+							<element minOccurs="0" name="RefundDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="RefundInvoicePaymentData" nillable="true" type="zns:RefundInvoicePaymentData" />
+							<element minOccurs="0" name="RefundNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="RefundTransactionTime" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="SecondRefundReferenceId" nillable="true" type="string" />
+							<element minOccurs="0" name="SettledOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="SoftDescriptor" nillable="true" type="string" />
+							<element minOccurs="0" name="SoftDescriptorPhone" nillable="true" type="string" />
+							<element minOccurs="0" name="SourceType" nillable="true" type="string" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="SubmittedOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TransferredToAccounting" nillable="true" type="string" />
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+			                <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+			                <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="RefundInvoicePayment">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="InvoicePaymentId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RefundAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="RefundId" nillable="true" type="zns:ID" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="RefundTransactionLog">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="BatchId" nillable="true" type="string" />
+							<element minOccurs="0" name="Gateway" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayReasonCode" nillable="true" type="string"/>
+							<element minOccurs="0" name="GatewayReasonCodeDescription" nillable="true" type="string"/>
+							<element minOccurs="0" name="GatewayState" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayTransactionType" nillable="true" type="string" />
+							<element minOccurs="0" name="RefundId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RequestString" nillable="true" type="string"/>
+							<element minOccurs="0" name="ResponseString" nillable="true" type="string"/>
+							<element minOccurs="0" name="TransactionDate" nillable="true" type="dateTime" />
+               				<element minOccurs="0" name="TransactionId" nillable="true" type="string"/>
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="InvoiceItem" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+                            <element minOccurs="0" name="AppliedToInvoiceItemId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="ChargeAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="ChargeDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ChargeDescription" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeId" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeName" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeType" nillable="true" type="string" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="ProcessingType" nillable="true" type="decimal"/>
+							<element minOccurs="0" name="ProductDescription" nillable="true" type="string" />
+							<element minOccurs="0" name="ProductId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="ProductName" nillable="true" type="string" />
+							<element minOccurs="0" name="Quantity" nillable="true" type="decimal" />
+							<element minOccurs="0" name="RatePlanChargeId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RevRecCode" nillable="true" type="string" />
+							<element minOccurs="0" name="RevRecStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="RevRecTriggerCondition" nillable="true" type="string" />
+							<element minOccurs="0" name="ServiceEndDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ServiceStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="SKU" nillable="true" type="string" />
+							<element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="SubscriptionNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="UnitPrice" nillable="true" type="decimal" />
+							<element minOccurs="0" name="UOM" nillable="true" type="string" />
+              				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="InvoicePayment">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="Amount" nillable="true" type="decimal" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="PaymentId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RefundAmount" nillable="true" type="decimal" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Payment" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="Amount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="AuthTransactionId" nillable="true" type="string" />
+							<element minOccurs="0" name="BankIdentificationNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="CancelledOn" nillable="true" type="dateTime"/>
+							<element minOccurs="0" name="Comment" nillable="true" type="string" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="EffectiveDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Gateway" nillable="true" type="string"  />
+							<element minOccurs="0" name="GatewayOptionData" nillable="true" type="zns:GatewayOptionData" />
+							<element minOccurs="0" name="GatewayOrderId" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayResponse" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayResponseCode" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayState" nillable="true" type="string" />
+							<element minOccurs="0" name="InvoicePaymentData" nillable="true" type="zns:InvoicePaymentData" />
+							<element minOccurs="0" name="MarkedForSubmissionOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="PaymentMethodId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="PaymentMethodSnapshotId" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="PaymentNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="ReferenceId" nillable="true" type="string" />
+							<element minOccurs="0" name="RefundAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="SecondPaymentReferenceId" nillable="true" type="string" />
+							<element minOccurs="0" name="SettledOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="SoftDescriptor" nillable="true" type="string" />
+							<element minOccurs="0" name="SoftDescriptorPhone" nillable="true" type="string" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="SubmittedOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TransferredToAccounting" nillable="true" type="string" />
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+               			    <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               			    <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="PaymentTransactionLog">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AVSResponseCode" nillable="true" type="string"/>
+							<element minOccurs="0" name="BatchId" nillable="true" type="string" />
+                            <element minOccurs="0" name="CVVResponseCode" nillable="true" type="string"/>
+                            <element minOccurs="0" name="Gateway" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayReasonCode" nillable="true" type="string"/>
+							<element minOccurs="0" name="GatewayReasonCodeDescription" nillable="true" type="string"/>
+							<element minOccurs="0" name="GatewayState" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayTransactionType" nillable="true" type="string"/>
+							<element minOccurs="0" name="PaymentId" nillable="true" type="zns:ID"/>
+							<element minOccurs="0" name="RequestString" nillable="true" type="string"/>
+							<element minOccurs="0" name="ResponseString" nillable="true" type="string"/>
+							<element minOccurs="0" name="TransactionDate" nillable="true" type="dateTime" />
+               				<element minOccurs="0" name="TransactionId" nillable="true" type="string"/>
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="PaymentMethod">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AchAbaCode" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountName" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountNumberMask" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountType" nillable="true" type="string" />
+							<element minOccurs="0" name="AchBankName" nillable="true" type="string" />
+							<element minOccurs="0" name="Active" nillable="true" type="boolean" />
+							<element minOccurs="0" name="BankIdentificationNumber" nillable="true" type="string" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="CreditCardAddress1" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardAddress2" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardCity" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardCountry" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardExpirationMonth" nillable="true" type="int" />
+							<element minOccurs="0" name="CreditCardExpirationYear" nillable="true" type="int" />
+							<element minOccurs="0" name="CreditCardHolderName" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardMaskNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardPostalCode" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardSecurityCode" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardState" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardType" nillable="true" type="string" />
+							<element minOccurs="0" name="DeviceSessionId" nillable="true" type="string" />
+							<element minOccurs="0" name="Email" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayOptionData" nillable="true" type="zns:GatewayOptionData" />
+							<element minOccurs="0" name="IPAddress" nillable="true" type="string" />
+							<element minOccurs="0" name="LastFailedSaleTransactionDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="LastTransactionDateTime" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="LastTransactionStatus" nillable="true" type="string" />
+							<element minOccurs="0" name="MaxConsecutivePaymentFailures" nillable="true" type="short" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="NumConsecutiveFailures" nillable="true" type="int" />
+							<element minOccurs="0" name="PaymentMethodStatus" nillable="true" type="string"/>
+							<element minOccurs="0" name="PaymentRetryWindow" nillable="true" type="short" />
+							<element minOccurs="0" name="PaypalBaid" nillable="true" type="string" /> 
+							<element minOccurs="0" name="PaypalEmail" nillable="true" type="string" />
+							<element minOccurs="0" name="PaypalPreapprovalKey" nillable="true" type="string" />
+							<element minOccurs="0" name="PaypalType" nillable="true" type="string" />
+							<element minOccurs="0" name="Phone" nillable="true" type="string" />
+							<element minOccurs="0" name="SecondTokenId" nillable="true" type="string" />
+							<element minOccurs="0" name="SkipValidation" nillable="true" type="boolean" />
+							<element minOccurs="0" name="TokenId" nillable="true" type="string" />
+							<element minOccurs="0" name="TotalNumberOfErrorPayments" nillable="true" type="int"/>
+							<element minOccurs="0" name="TotalNumberOfProcessedPayments" nillable="true" type="int"/>
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+               				<element minOccurs="0" name="UseDefaultRetryRule" nillable="true" type="boolean" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+            <complexType name="PaymentMethodTransactionLog">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>							    
+						    <element minOccurs="0" name="Gateway" nillable="true" type="string" />								   						
+							<element minOccurs="0" name="GatewayReasonCode" nillable="true" type="string"/>
+							<element minOccurs="0" name="GatewayReasonCodeDescription" nillable="true" type="string"/>	
+							<element minOccurs="0" name="GatewayTransactionType" nillable="true" type="string"/>													
+							<element minOccurs="0" name="PaymentMethodId" nillable="true" type="string"/>	
+							<element minOccurs="0" name="PaymentMethodType" nillable="true" type="string"/>												
+							<element minOccurs="0" name="RequestString" nillable="true" type="string"/>
+							<element minOccurs="0" name="ResponseString" nillable="true" type="string"/>
+							<element minOccurs="0" name="TransactionDate" nillable="true" type="string"/>							
+               				<element minOccurs="0" name="TransactionId" nillable="true" type="string"/>              				
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+		<complexType name="PaymentMethodSnapshot">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AchAbaCode" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountName" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountNumberMask" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountType" nillable="true" type="string" />
+							<element minOccurs="0" name="AchBankName" nillable="true" type="string" />
+							<element minOccurs="0" name="BankBranchCode" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankCheckDigit" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankCity" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankCode" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankIdentificationNumber" nillable="true" type="string"/>
+			               	<element minOccurs="0" name="BankName" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="BankPostalCode" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="BankStreetName" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="BankStreetNumber" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="BankTransferAccountName" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankTransferAccountNumber" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankTransferAccountNumberMask" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankTransferAccountType" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="BankTransferType" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BusinessIdentificationCode" nillable="true" type="string"/> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="City" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="Country" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="CreditCardAddress1" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardAddress2" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardCity" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardCountry" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardExpirationMonth" nillable="true" type="int" />
+							<element minOccurs="0" name="CreditCardExpirationYear" nillable="true" type="int" />
+							<element minOccurs="0" name="CreditCardHolderName" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardMaskNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardPostalCode" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardState" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardType" nillable="true" type="string" />
+							<element minOccurs="0" name="DeviceSessionId" nillable="true" type="string" />
+							<element minOccurs="0" name="Email" nillable="true" type="string"/>
+							<element minOccurs="0" name="ExistingMandate" nillable="true" type="string"/> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="FirstName" nillable="true" type="string"/> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="IBAN" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="IPAddress" nillable="true" type="string"/>
+							<element minOccurs="0" name="LastFailedSaleTransactionDate" nillable="true" type="dateTime"/>
+							<element minOccurs="0" name="LastName" nillable="true" type="string"/> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="LastTransactionDateTime" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="LastTransactionStatus" nillable="true" type="string" />
+							<element minOccurs="0" name="MandateCreationDate" nillable="true" type="dateTime" /> <!-- this field use for bank transfer payment method -->
+        					<element minOccurs="0" name="MandateID" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+        					<element minOccurs="0" name="MandateReceived" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+        					<element minOccurs="0" name="MandateUpdateDate" nillable="true" type="dateTime" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="MaxConsecutivePaymentFailures" nillable="true" type="short" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="NumConsecutiveFailures" nillable="true" type="int"/>
+							<element minOccurs="0" name="PaymentMethodId" nillable="true" type="zns:ID"/>
+							<element minOccurs="0" name="PaymentMethodStatus" nillable="true" type="string"/>
+							<element minOccurs="0" name="PaymentRetryWindow" nillable="true" type="short"/>
+							<element minOccurs="0" name="PaypalBaid" nillable="true" type="string" /> 
+							<element minOccurs="0" name="PaypalEmail" nillable="true" type="string" />
+							<element minOccurs="0" name="PaypalPreapprovalKey" nillable="true" type="string" />
+							<element minOccurs="0" name="PaypalType" nillable="true" type="string" />
+							<element minOccurs="0" name="Phone" nillable="true" type="string" />
+							<element minOccurs="0" name="PostalCode" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="SecondTokenId" nillable="true" type="string"/>
+							<element minOccurs="0" name="State" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="StreetName" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="StreetNumber" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="TokenId" nillable="true" type="string"/>
+							<element minOccurs="0" name="TotalNumberOfErrorPayments" nillable="true" type="int"/>
+							<element minOccurs="0" name="TotalNumberOfProcessedPayments" nillable="true" type="int"/>
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+			               	<element minOccurs="0" name="UseDefaultRetryRule" nillable="true" type="boolean" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Product" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+						  <element minOccurs="0" name="AllowFeatureChanges" nillable="true" type="boolean" />
+							<element minOccurs="0" name="Category" nillable="true" type="string" />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="EffectiveEndDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="EffectiveStartDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="SKU" nillable="true" type="string" />
+			               	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+      <complexType name="Feature" >
+        <complexContent>
+          <extension base="ons:zObject">
+            <sequence>
+              <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+              <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"/>
+              <element minOccurs="0" name="Description" nillable="true" type="string" />
+              <element minOccurs="0" name="FeatureCode" nillable="false" type="string" />
+              <element minOccurs="0" name="Name" nillable="false" type="string" />
+              <element minOccurs="0" name="Status" nillable="true" type="string" />
+              <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+              <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+            </sequence>
+          </extension>
+        </complexContent>
+      </complexType>
+      <complexType name="ProductFeature" >
+        <complexContent>
+          <extension base="ons:zObject">
+            <sequence>
+              <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+              <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"/>
+              <element minOccurs="0" name="FeatureId" nillable="false" type="zns:ID" />
+              <element minOccurs="0" name="ProductId" nillable="false" type="zns:ID" />
+              <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+              <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+            </sequence>
+          </extension>
+        </complexContent>
+      </complexType>
+			<complexType name="ProductRatePlan" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+			               	<element minOccurs="0" name="ActiveCurrencies" nillable="true" type="string"  />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="EffectiveEndDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="EffectiveStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="ProductId" nillable="true" type="zns:ID" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="ProductRatePlanCharge" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="ApplyDiscountTo" nillable="true" type="string"  />
+							<element minOccurs="0" name="BillCycleDay" nillable="true" type="int" />
+							<element minOccurs="0" name="BillCycleType" nillable="true" type="string" />
+							<element minOccurs="0" name="BillingPeriod" nillable="true" type="string"  />
+							<element minOccurs="0" name="BillingPeriodAlignment" nillable="true" type="string" />
+               				<element minOccurs="0" name="ChargeModel" nillable="true" type="string"  />
+							<element minOccurs="0" name="ChargeType" nillable="true" type="string"  />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="DefaultQuantity" nillable="true" type="decimal" />
+							<element minOccurs="0" name="DeferredRevenueAccount" nillable="true" type="string"   />
+							<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="DiscountLevel" nillable="true" type="string" />
+							<element minOccurs="0" name="IncludedUnits" nillable="true" type="decimal" />
+							<element minOccurs="0" name="LegacyRevenueReporting" nillable="true" type="boolean" />
+							<element minOccurs="0" name="MaxQuantity" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="MinQuantity" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="NumberOfPeriod" nillable="true" type="long"  />
+							<element minOccurs="0" name="OverageCalculationOption" nillable="true" type="string"  />
+							<element minOccurs="0" name="OverageUnusedUnitsCreditOption" nillable="true" type="string"  />
+							<element minOccurs="0" name="PriceChangeOption" nillable="true" type="string" />
+							<element minOccurs="0" name="PriceIncreasePercentage" nillable="true" type="decimal" />
+							<element minOccurs="0" name="ProductRatePlanChargeTierData" nillable="true" type="zns:ProductRatePlanChargeTierData"  />
+							<element minOccurs="0" name="ProductRatePlanId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RecognizedRevenueAccount" nillable="true" type="string"  />
+							<element minOccurs="0" name="RevenueRecognitionRuleName" nillable="true" type="string"  />
+							<element minOccurs="0" name="RevRecCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="RevRecTriggerCondition" nillable="true" type="string"  />
+							<element minOccurs="0" name="SmoothingModel" nillable="true" type="string"  />
+							<element minOccurs="0" name="SpecificBillingPeriod" nillable="true" type="long" />
+							<element minOccurs="0" name="TriggerEvent" nillable="true" type="string" />
+							<element minOccurs="0" name="UOM" nillable="true" type="string" />
+			               	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+			               	<element minOccurs="0" name="UpToPeriods" nillable="true" type="long"  />
+			               	<element minOccurs="0" name="UsageRecordRatingOption" nillable="true" type="string"  />
+			               	<element minOccurs="0" name="UseDiscountSpecificAccountingCode" nillable="true" type="boolean" />
+							<element minOccurs="0" name="UseTenantDefaultForPriceChange" nillable="true" type="boolean" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="ProductRatePlanChargeTier">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Currency" nillable="true" type="string" />
+							<element minOccurs="0" name="DiscountAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="DiscountPercentage" nillable="true" type="decimal" />
+							<element minOccurs="0" name="EndingUnit" nillable="true" type="decimal" />
+							<element minOccurs="0" name="IsOveragePrice" nillable="true" type="boolean"  />
+							<element minOccurs="0" name="Price" nillable="true" type="decimal" />
+							<element minOccurs="0" name="PriceFormat" nillable="true" type="string" />
+							<element minOccurs="0" name="ProductRatePlanChargeId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="StartingUnit" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Tier" nillable="true" type="int" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="GatewayOption" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="name" nillable="true" type="string" />
+							<element minOccurs="0" name="value" nillable="true" type="string" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="RatePlan">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AmendmentId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AmendmentSubscriptionRatePlanId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AmendmentType" nillable="true" type="string" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Name" nillable="true" type="string" /><!-- do we need this? -->
+							<element minOccurs="0" name="ProductRatePlanId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="SubscriptionProductFeature" >
+		        <complexContent>
+		          <extension base="ons:zObject">
+		            <sequence>
+		              <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+		              <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+		              <element minOccurs="0" name="Description" nillable="true" type="string" />
+		              <element minOccurs="0" name="FeatureCode" nillable="true" type="string" />
+		              <element minOccurs="0" name="FeatureId" nillable="false" type="zns:ID" />
+		              <element minOccurs="0" name="Name" nillable="true" type="string" />
+		              <element minOccurs="0" name="RatePlanId" nillable="true" type="zns:ID" />
+		              <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+		              <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+		            </sequence>
+		          </extension>
+		        </complexContent>
+		      </complexType>
+			<complexType name="RatePlanCharge" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="ApplyDiscountTo" nillable="true" type="string" />
+							<element minOccurs="0" name="BillCycleDay" nillable="true" type="int" />
+							<element minOccurs="0" name="BillCycleType" nillable="true" type="string" />
+							<element minOccurs="0" name="BillingPeriod" nillable="true" type="string" />
+							<element minOccurs="0" name="BillingPeriodAlignment" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargedThroughDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ChargeModel" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeType" nillable="true" type="string" />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="DiscountAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="DiscountLevel" nillable="true" type="string" />
+							<element minOccurs="0" name="DiscountPercentage" nillable="true" type="decimal" />
+							<element minOccurs="0" name="DMRC" nillable="true" type="decimal" />
+							<element minOccurs="0" name="DTCV" nillable="true" type="decimal" />
+							<element minOccurs="0" name="EffectiveEndDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="EffectiveStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="IncludedUnits" nillable="true" type="decimal" />
+							<element minOccurs="0" name="IsLastSegment" nillable="true" type="boolean"  />
+							<element minOccurs="0" name="MRR" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="NumberOfPeriods" nillable="true" type="long" />
+							<element minOccurs="0" name="OriginalId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="OverageCalculationOption" nillable="true" type="string"  />
+							<element minOccurs="0" name="OveragePrice" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="OverageUnusedUnitsCreditOption" nillable="true" type="string"  />
+							<element minOccurs="0" name="Price" nillable="true" type="decimal" />
+							<element minOccurs="0" name="PriceChangeOption" nillable="true" type="string" />
+							<element minOccurs="0" name="PriceIncreasePercentage" nillable="true" type="decimal" />
+							<element minOccurs="0" name="ProcessedThroughDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ProductRatePlanChargeId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="Quantity" nillable="true" type="decimal" />
+							<element minOccurs="0" name="RatePlanId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RevRecCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="RevRecTriggerCondition" nillable="true" type="string"  />
+							<element minOccurs="0" name="RolloverBalance" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Segment" nillable="true" type="int" />
+							<element minOccurs="0" name="SpecificBillingPeriod" nillable="true" type="long" />
+							<element minOccurs="0" name="TCV" nillable="true" type="decimal" />
+							<element minOccurs="0" name="TriggerDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TriggerEvent" nillable="true" type="string" />
+							<element minOccurs="0" name="UnusedUnitsCreditRates" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="UOM" nillable="true" type="string" />
+			               	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+			               	<element minOccurs="0" name="UpToPeriods" nillable="true" type="long"  />
+							<element minOccurs="0" name="UsageRecordRatingOption" nillable="true" type="string"  />
+			               	<element minOccurs="0" name="UseDiscountSpecificAccountingCode" nillable="true" type="boolean"  />
+			               	<element minOccurs="0" name="Version" nillable="true" type="long" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="RatePlanChargeTier">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="EndingUnit" nillable="true" type="decimal" />
+							<element minOccurs="0" name="IsOveragePrice" nillable="true" type="boolean" />
+							<element minOccurs="0" name="Price" nillable="true" type="decimal" />
+							<element minOccurs="0" name="PriceFormat" nillable="true" type="string" />
+							<element minOccurs="0" name="RatePlanChargeId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="StartingUnit" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="Tier" nillable="true" type="int" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Subscription" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AutoRenew" nillable="true" type="boolean" />
+							<element minOccurs="0" name="CancelledDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ContractAcceptanceDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ContractEffectiveDate" nillable="true" type="dateTime" />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="InitialTerm" nillable="true" type="int" />
+							<element minOccurs="0" name="IsInvoiceSeparate" nillable="true" type="boolean" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="Notes" nillable="true" type="string" />
+                     		<element minOccurs="0" name="OriginalCreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="OriginalId" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="PreviousSubscriptionId" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="RenewalSetting" nillable="true" type="string" />
+							<element minOccurs="0" name="RenewalTerm" nillable="true" type="int" />
+							<element minOccurs="0" name="ServiceActivationDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="SubscriptionEndDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="SubscriptionStartDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="TermEndDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TermStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TermType" nillable="true" type="string" />
+			               	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Version" nillable="true" type="int" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+
+	   		 <complexType name="Usage" >
+	    		<complexContent>
+	    		 <extension base="ons:zObject">
+	     			 <sequence>
+		      			 <element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+		      			 <element minOccurs="0" name="AccountNumber" nillable="true" type="string" />
+		      			 <element minOccurs="0" name="ChargeId" nillable="true" type="zns:ID" />
+		      			 <element minOccurs="0" name="ChargeNumber" nillable="true" type="string"/>
+		               	 <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+		                 <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+		      			 <element minOccurs="0" name="Description" nillable="true" type="string" />
+		    			 <element minOccurs="0" name="EndDateTime" nillable="true" type="dateTime" />
+                         <element minOccurs="0" name="ImportId" nillable="true" type="zns:ID" />
+		    			 <element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+		    			 <element minOccurs="0" name="InvoiceNumber" nillable="true" type="string" />
+		       			 <element minOccurs="0" name="Quantity" nillable="true" type="decimal" />
+		       			 <element minOccurs="0" name="RbeStatus" nillable="true" type="string"/>
+		    			 <element minOccurs="0" name="SourceName" nillable="true" type="string" />
+		        		 <element minOccurs="0" name="SourceType" nillable="true" type="string"/>		       			 
+		       			 <element minOccurs="0" name="StartDateTime" nillable="true" type="dateTime" />
+		       			 <element minOccurs="0" name="SubmissionDateTime" nillable="true" type="dateTime" />
+		       			 <element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+		       			 <element minOccurs="0" name="SubscriptionNumber" nillable="true" type="string"/>
+		       			 <element minOccurs="0" name="UOM" nillable="true" type="string" />
+		                 <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+		                 <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+	                 </sequence>
+	            </extension>
+	           </complexContent>
+	   		</complexType>
+          <complexType name="Import">
+            <complexContent>
+             <extension base="ons:zObject">
+                 <sequence>
+                     <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"/>
+                     <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"/>
+                     <element minOccurs="0" name="FileContent" nillable="true" type="xs:base64Binary"/>
+                     <element minOccurs="0" name="ImportedCount" nillable="true" type="xs:int"/>
+                     <element minOccurs="0" name="ImportType" nillable="true" type="string"/>
+                     <element minOccurs="0" name="Md5" nillable="true" type="string"/>
+                     <element minOccurs="0" name="Name" nillable="true" type="string"/>
+                     <element minOccurs="0" name="OriginalResourceUrl" nillable="true" type="string"/>
+                     <element minOccurs="0" name="ResultResourceUrl" nillable="true" type="string"/>
+                     <element minOccurs="0" name="Status" nillable="true" type="string"/>
+                     <element minOccurs="0" name="StatusReason" nillable="true" type="string"/>
+                     <element minOccurs="0" name="TotalCount" nillable="true" type="xs:int"/>
+                     <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"/>
+                     <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"/>
+                 </sequence>
+               </extension>
+              </complexContent>
+            </complexType>
+          <complexType name="Export">
+            <complexContent>
+             <extension base="ons:zObject">
+                <sequence>
+                      <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"/>
+                      <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"/>
+                      <element minOccurs="0" name="Encrypted" nillable="true" type="xs:boolean" />
+                      <element minOccurs="0" name="FileId" nillable="true" type="zns:ID"/>
+                      <element minOccurs="0" name="Format" nillable="true" type="string"/>
+                      <element minOccurs="0" name="Name" nillable="true" type="string" />
+                      <element minOccurs="0" name="Query" nillable="true" type="string"/>
+                      <element minOccurs="0" name="Size" nillable="true" type="xs:int"/>
+                      <element minOccurs="0" name="Status" nillable="true" type="string"/>
+                      <element minOccurs="0" name="StatusReason" nillable="true" type="string"/>
+                      <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"/>
+                      <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"/>
+                      <element minOccurs="0" name="Zip" nillable="true" type="xs:boolean"/>
+                    </sequence>
+               </extension>
+              </complexContent>
+            </complexType>
+          <complexType name="CommunicationProfile">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+					       	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+					       	<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="ProfileName" nillable="true" type="string" />
+					       	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+						</sequence>
+					</extension>
+				</complexContent>
+		  </complexType>
+
+		
+
+
+		
+				
+   		</schema>
+		<schema attributeFormDefault="qualified" elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://api.zuora.com/">
+		<import namespace="http://object.api.zuora.com/" />
+			<simpleType name="ID">
+				<restriction base="xs:string">
+					<pattern value='[a-zA-Z0-9]{32}|\d+' />
+				</restriction>
+			</simpleType>
+			<complexType name="LoginResult">
+				<sequence>
+					<element name="Session" nillable="true" type="xs:string" />
+					<element name="ServerUrl" nillable="true" type="xs:string" />
+				</sequence>
+			</complexType>
+			<complexType name="SubscribeRequest">
+				<sequence>
+					<element minOccurs="0" name="Account" nillable="true" type="ons:Account" />
+					<element minOccurs="0" name="PaymentMethod" nillable="true" type="ons:PaymentMethod" />
+					<element minOccurs="0" name="BillToContact" nillable="true" type="ons:Contact" />
+					<element minOccurs="0" name="PreviewOptions" nillable="true" type="zns:PreviewOptions"  />
+					<element minOccurs="0" name="SoldToContact" nillable="true" type="ons:Contact" />
+					<element minOccurs="0" name="SubscribeOptions" nillable="true" type="zns:SubscribeOptions" />
+					<element minOccurs="0" name="SubscriptionData" nillable="true" type="zns:SubscriptionData" />
+				</sequence>
+			</complexType>
+			<complexType name="SubscribeOptions">
+				<sequence>
+					<element minOccurs="0" name="ExternalPaymentOptions" nillable="true" type="zns:ExternalPaymentOptions" />
+					<element minOccurs="0" name="GenerateInvoice" nillable="true" type="xs:boolean" />
+					<element minOccurs="0" name="ProcessPayments" nillable="true" type="xs:boolean" />
+					<element minOccurs="0" name="SubscribeInvoiceProcessingOptions" nillable="true" type="zns:SubscribeInvoiceProcessingOptions" />
+				</sequence>
+			</complexType>			
+			<complexType name="SubscribeInvoiceProcessingOptions">
+			    <sequence>
+			        <element minOccurs="0" name="InvoiceDate" nillable="true" type="dateTime" />
+			        <element minOccurs="0" name="InvoiceProcessingScope" nillable="true" type="xs:string" />
+			        <element minOccurs="0" name="InvoiceTargetDate" nillable="true" type="dateTime" />
+			    </sequence>
+			</complexType>
+			<complexType name="SubscriptionData">
+				<sequence>
+					<element minOccurs="0" name="Subscription" nillable="true" type="ons:Subscription" />
+					<element minOccurs="0" maxOccurs="unbounded" name="RatePlanData" nillable="true" type="zns:RatePlanData" />
+				</sequence>
+			</complexType>
+			<complexType name="RatePlanData">
+				<sequence>
+					<element minOccurs="0" name="RatePlan" nillable="true" type="ons:RatePlan" />
+					<element maxOccurs="unbounded" minOccurs="0" name="RatePlanChargeData" nillable="true" type="zns:RatePlanChargeData" />
+					<element minOccurs="0" maxOccurs="1" name="SubscriptionProductFeatureList" nillable="true" type="zns:SubscriptionProductFeatureList"  />
+				</sequence>
+			</complexType>
+					<complexType name="SubscriptionProductFeatureList">
+						<sequence>
+							<element maxOccurs="100" minOccurs="0" name="SubscriptionProductFeature" nillable="true" type="ons:SubscriptionProductFeature" />
+				</sequence>
+			</complexType>
+				<complexType name="RatePlanChargeData">
+					<sequence>
+						<element minOccurs="0" name="RatePlanCharge" nillable="true" type="ons:RatePlanCharge" />
+						<element maxOccurs="unbounded" minOccurs="0" name="RatePlanChargeTier" nillable="true" type="ons:RatePlanChargeTier" />
+					</sequence>
+				</complexType>
+				<complexType name="ProductRatePlanChargeTierData">
+					<sequence>
+						<element maxOccurs="unbounded" minOccurs="0" name="ProductRatePlanChargeTier" nillable="true" type="ons:ProductRatePlanChargeTier" />
+					</sequence>
+				</complexType>
+				<complexType name="InvoicePaymentData">
+					<sequence>
+						<element maxOccurs="unbounded" minOccurs="0" name="InvoicePayment" nillable="true" type="ons:InvoicePayment" />
+					</sequence>
+				</complexType>
+				<complexType name="RefundInvoicePaymentData">
+					<sequence>
+						<element maxOccurs="unbounded" minOccurs="0" name="RefundInvoicePayment" nillable="true" type="ons:RefundInvoicePayment" />
+					</sequence>
+				</complexType>
+			<complexType name="GatewayOptionData">
+				<sequence>
+					<element maxOccurs="200" minOccurs="0" name="GatewayOption" nillable="true" type="ons:GatewayOption" />
+				</sequence>
+			</complexType>
+				<complexType name="InvoiceData">
+					<sequence>
+						<element minOccurs="0" name="Invoice" nillable="true" type="ons:Invoice" />
+						<element minOccurs="0" maxOccurs="unbounded" name="InvoiceItem" nillable="true" type="ons:InvoiceItem" />
+					</sequence>
+				</complexType>
+				<complexType name="InvoiceResult">
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="Invoice" nillable="true" type="ons:Invoice" />
+					</sequence>
+				</complexType>
+				<complexType name="PreviewOptions">
+					<sequence>
+						<element minOccurs="0" name="EnablePreviewMode" nillable="true" type="boolean" />
+						<element minOccurs="0" name="NumberOfPeriods" nillable="true" type="int" />
+						<element minOccurs="0" name="PreviewThroughTermEnd" nillable="true" type="boolean" />
+					</sequence>
+				</complexType>
+		
+			<complexType name="SubscribeResult">
+				<sequence>
+					<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+					<element minOccurs="0" name="AccountNumber" nillable="true" type="string" />
+					<element minOccurs="0" maxOccurs="unbounded" name="Errors" nillable="true" type="zns:Error" />
+					<element minOccurs="0" maxOccurs="1" name="GatewayResponse" nillable="true" type="string" />
+					<element minOccurs="0" maxOccurs="1" name="GatewayResponseCode" nillable="true" type="string" />
+					<element minOccurs="0" maxOccurs="unbounded" name="InvoiceData" nillable="true" type="zns:InvoiceData" />
+					<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+					<element minOccurs="0" name="InvoiceNumber" nillable="true" type="string" />
+					<element minOccurs="0" name="InvoiceResult" nillable="true" type="zns:InvoiceResult" />
+					<element minOccurs="0" name="PaymentId" nillable="true" type="zns:ID" />
+					<element minOccurs="0" name="PaymentTransactionNumber" nillable="true" type="string" />
+					<element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+					<element minOccurs="0" name="SubscriptionNumber" nillable="true" type="string" />
+					<element minOccurs="0" maxOccurs="1" name="Success" type="boolean" />
+					<element minOccurs="0" name="TotalMrr" nillable="true" type="decimal" />
+					<element minOccurs="0" name="TotalTcv" nillable="true" type="decimal" />
+				</sequence>
+			</complexType>
+			<complexType name="SaveResult">
+				<sequence>
+					<element minOccurs="0" maxOccurs="unbounded" name="Errors" nillable="true" type="zns:Error" />
+					<element minOccurs="0" maxOccurs="1" name="Id" nillable="true" type="zns:ID" />
+					<element minOccurs="0" maxOccurs="1" name="Success" type="boolean" />
+				</sequence>
+			</complexType>
+			<complexType name="DeleteResult">
+				<sequence>
+					<element name="errors" minOccurs="0" maxOccurs="unbounded" type="zns:Error" nillable="true" />
+					<element name="id" minOccurs="0" maxOccurs="1" type="zns:ID" nillable="true" />
+					<element name="success" minOccurs="0" maxOccurs="1" type="boolean" />
+				</sequence>
+			</complexType>
+				<complexType name="ExecuteResult">
+					<sequence>
+						<element name="Errors" minOccurs="0" maxOccurs="unbounded" type="zns:Error" nillable="true" />
+						<element name="Id" minOccurs="0" maxOccurs="1" type="zns:ID" nillable="true" />
+						<element name="Success" minOccurs="0" maxOccurs="1" type="boolean" />
+					</sequence>
+				</complexType>
+			<simpleType name="QueryLocator">
+				<restriction base="xs:string" />
+			</simpleType>
+			<complexType name="QueryResult">
+				<sequence>
+					<element name="done" type="xs:boolean" />
+					<element name="queryLocator" type="zns:QueryLocator" nillable="true" />
+					<element name="records" type="ons:zObject" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+					<element name="size" type="xs:int" />
+				</sequence>
+			</complexType>
+			<complexType name="Error">
+				<sequence>
+					<element minOccurs="0" name="Code" nillable="true" type="zns:ErrorCode" />
+					<element minOccurs="0" name="Message" nillable="true" type="string" />
+					<element minOccurs="0" name="Field" nillable="true" type="string" />
+				</sequence>
+			</complexType>
+			
+			
+			<simpleType name="ErrorCode">
+				<restriction base="xs:string">
+					<enumeration value="API_DISABLED" />
+					<enumeration value="CANNOT_DELETE" />
+					<enumeration value="CREDIT_CARD_PROCESSING_FAILURE" />
+					<enumeration value="DUPLICATE_VALUE" />
+					<enumeration value="INVALID_FIELD" />
+					<enumeration value="INVALID_LOGIN" />
+					<enumeration value="INVALID_SESSION" />
+					<enumeration value="INVALID_TYPE" />
+					<enumeration value="INVALID_ID" />
+					<enumeration value="INVALID_VALUE" />
+					<enumeration value="INVALID_VERSION" />
+					<enumeration value="LOCK_COMPETITION"  />
+					<enumeration value="MALFORMED_QUERY" />
+					<enumeration value="MAX_RECORDS_EXCEEDED" />
+					<enumeration value="MISSING_REQUIRED_VALUE" />
+					<enumeration value="NO_PERMISSION" />
+					<enumeration value="SERVER_UNAVAILABLE" />
+					<enumeration value="UNKNOWN_ERROR" />
+					<enumeration value="TRANSACTION_FAILED" />
+					<enumeration value="INVALID_TEMPLATE" />
+					<enumeration value="ACCOUNTING_PERIOD_CLOSED" />
+					<enumeration value="BATCH_FAIL_ERROR"/>
+					<enumeration value="PDF_QUERY_ERROR" />
+					<enumeration value="REQUEST_EXCEEDED_LIMIT" />
+					<enumeration value="REQUEST_EXCEEDED_RATE" />
+					<enumeration value="REQUEST_REJECTED" />
+					<enumeration value="TEMPORARY_ERROR"  />
+					<enumeration value="TRANSACTION_TERMINATED"  />
+					<enumeration value="TRANSACTION_TIMEOUT"  />
+				</restriction>
+			</simpleType>
+			<element name="login">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="1" name="username" type="string" />
+						<element minOccurs="0" maxOccurs="1" name="password" type="string" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="loginResponse">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="1" name="result" type="zns:LoginResult" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="subscribe">
+				<complexType>
+					<sequence>
+						<element name="subscribes" minOccurs="0" maxOccurs="unbounded" type="zns:SubscribeRequest" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="subscribeResponse">
+				<complexType>
+					<sequence>
+						<element name="result" minOccurs="0" maxOccurs="unbounded" type="zns:SubscribeResult" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="create">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="zObjects" type="ons:zObject" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="createResponse">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="result" type="zns:SaveResult" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="generate">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="zObjects" type="ons:zObject" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="generateResponse">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="result" type="zns:SaveResult" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="update">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="zObjects" type="ons:zObject" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="updateResponse">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="result" type="zns:SaveResult" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="delete">
+				<complexType>
+					<sequence>
+						<element name="type" type="string" minOccurs="1" maxOccurs="1" />
+						<element name="ids" type="zns:ID" minOccurs="0" maxOccurs="unbounded" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="deleteResponse">
+				<complexType>
+					<sequence>
+						<element name="result" type="zns:DeleteResult" minOccurs="0" maxOccurs="unbounded" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="execute">
+				<complexType>
+					<sequence>
+						<element name="type" type="string" minOccurs="1" maxOccurs="1" />
+						<element name="synchronous" type="boolean" minOccurs="1" maxOccurs="1" />
+						<element name="ids" type="zns:ID" minOccurs="0" maxOccurs="unbounded" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="executeResponse">
+				<complexType>
+					<sequence>
+						<element name="result" type="zns:ExecuteResult" minOccurs="0" maxOccurs="unbounded" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="query">
+				<complexType>
+					<sequence>
+						<element name="queryString" type="xs:string" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="queryResponse">
+				<complexType>
+					<sequence>
+						<element name="result" type="zns:QueryResult" />
+					</sequence>
+				</complexType>
+			</element>
+
+           <element name="queryMore"> 
+                <complexType> 
+                    <sequence> 
+                        <element name="queryLocator" type="zns:QueryLocator"/> 
+                    </sequence> 
+                </complexType> 
+            </element> 
+            <element name="queryMoreResponse"> 
+                <complexType> 
+                    <sequence> 
+                        <element name="result" type="zns:QueryResult"/> 
+                    </sequence> 
+                </complexType> 
+            </element> 
+
+			<element name="SessionHeader">
+				<complexType>
+					<sequence>
+						<element name="session" type="string" />
+					</sequence>
+				</complexType>
+			</element>
+
+            <element name="QueryOptions">
+                <complexType>
+                    <sequence>
+                        <element name="batchSize" type="int" minOccurs="0"/>
+                        <element name="caseSensitive" type="boolean" minOccurs="0" />
+                    </sequence>
+                </complexType>
+            </element>
+
+			<element name="getUserInfoResponse">
+				<complexType>
+					<sequence>
+						<element minOccurs="1" maxOccurs="1" name="TenantId" type="string" />
+						<element minOccurs="1" maxOccurs="1" name="TenantName" type="string" />
+						<element minOccurs="1" maxOccurs="1" name="UserEmail" type="string" />
+						<element minOccurs="1" maxOccurs="1" name="UserFullName" type="string" />
+						<element minOccurs="1" maxOccurs="1" name="UserId" type="string" />
+						<element minOccurs="1" maxOccurs="1" name="Username" type="string" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="getUserInfo">
+				<complexType>
+					<sequence/>
+				</complexType>
+			</element>
+			<element name="DummyHeader">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" name="Account" nillable="true" type="ons:Account" />
+						<element minOccurs="0" name="AccountingCode" nillable="true" type="ons:AccountingCode" />
+						<element minOccurs="0" name="AccountingPeriod" nillable="true" type="ons:AccountingPeriod" />
+						<element minOccurs="0" name="Amendment" nillable="true" type="ons:Amendment" />
+						<element minOccurs="0" name="Invoice" nillable="true" type="ons:Invoice" />
+						<element minOccurs="0" name="InvoiceItem" nillable="true" type="ons:InvoiceItem" />
+						<element minOccurs="0" name="InvoicePayment" nillable="true" type="ons:InvoicePayment" />
+						<element minOccurs="0" name="Import" nillable="true" type="ons:Import" />
+						<element minOccurs="0" name="Payment" nillable="true" type="ons:Payment" />
+						<element minOccurs="0" name="PaymentMethodSnapshot" nillable="true" type="ons:PaymentMethodSnapshot" />
+						<element minOccurs="0" name="Product" nillable="true" type="ons:Product" />
+						<element minOccurs="0" name="Feature" nillable="true" type="ons:Feature" />
+						<element minOccurs="0" name="ProductFeature" nillable="true" type="ons:ProductFeature" />
+						<element minOccurs="0" name="ProductRatePlan" nillable="true" type="ons:ProductRatePlan" />
+						<element minOccurs="0" name="ProductRatePlanCharge" nillable="true" type="ons:ProductRatePlanCharge" />
+						<element minOccurs="0" name="ProductRatePlanChargeTier" nillable="true" type="ons:ProductRatePlanChargeTier" />
+						<element minOccurs="0" name="RatePlan" nillable="true" type="ons:RatePlan" />
+						<element minOccurs="0" name="RatePlanCharge" nillable="true" type="ons:RatePlanCharge" />
+						<element minOccurs="0" name="RatePlanChargeTier" nillable="true" type="ons:RatePlanChargeTier" />
+						<element minOccurs="0" name="Usage" nillable="true" type="ons:Usage" />
+						<element minOccurs="0" name="Refund" nillable="true" type="ons:Refund" />
+						<element minOccurs="0" name="RefundInvoicePayment" nillable="true" type="ons:RefundInvoicePayment" />				
+                        <element minOccurs="0" name="Export" nillable="true" type="ons:Export"  />
+						<element minOccurs="0" name="InvoiceItemAdjustment" nillable="true" type="ons:InvoiceItemAdjustment" />			
+						<element minOccurs="0" name="CommunicationProfile" nillable="true" type="ons:CommunicationProfile" />
+					</sequence>
+				</complexType>
+			</element>
+            	<element name="CallOptions">
+                        <complexType>
+                           <sequence>
+                               <element minOccurs="0" name="useSingleTransaction" nillable="true" type="boolean" />
+                           </sequence>
+                       	</complexType>
+                   	</element>
+				<complexType name="InvoiceProcessingOptions">
+				    <sequence>
+			        	<element minOccurs="0" name="InvoiceDate" nillable="true" type="dateTime" />
+				        <element minOccurs="0" name="InvoiceTargetDate" nillable="true" type="dateTime" />
+				    </sequence>
+				</complexType>
+				<complexType name="AmendOptions" >
+					<sequence>
+						<element minOccurs="0" name="ExternalPaymentOptions" nillable="true" type="zns:ExternalPaymentOptions" />
+						<element minOccurs="0" name="GenerateInvoice" nillable="true" type="xs:boolean" />
+				        <element minOccurs="0" name="InvoiceProcessingOptions" nillable="true" type="zns:InvoiceProcessingOptions" />
+						<element minOccurs="0" name="ProcessPayments" nillable="true" type="xs:boolean" />
+					</sequence>
+				</complexType>
+				<complexType name="AmendRequest">
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="Amendments" nillable="true" type="ons:Amendment" />
+						<element minOccurs="0" name="AmendOptions" nillable="true" type="zns:AmendOptions" />
+						<element minOccurs="0" name="PreviewOptions" nillable="true" type="zns:PreviewOptions" />
+					</sequence>
+				</complexType>
+				<element name="amend">
+					<complexType>
+						<sequence>
+							<element name="requests" minOccurs="0" maxOccurs="unbounded" type="zns:AmendRequest" />
+						</sequence>
+					</complexType>
+				</element>
+				<complexType name="AmendResult">
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="AmendmentIds" nillable="true" type="zns:ID" />
+						<element minOccurs="0" maxOccurs="unbounded" name="Errors" nillable="true" type="zns:Error" />
+	                    <element minOccurs="0" maxOccurs="1" name="GatewayResponse" nillable="true" type="string" />
+    					<element minOccurs="0" maxOccurs="1" name="GatewayResponseCode" nillable="true" type="string" />
+						<element minOccurs="0" maxOccurs="unbounded" name="InvoiceDatas" nillable="true" type="zns:InvoiceData" />
+						<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+						<element minOccurs="0" name="PaymentId" nillable="true" type="zns:ID" />
+						<element minOccurs="0" name="PaymentTransactionNumber" nillable="true" type="string" />
+						<element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+						<element minOccurs="0" maxOccurs="1" name="Success" type="boolean" />
+						<element minOccurs="0" name="TotalDeltaMrr" nillable="true" type="decimal" />
+						<element minOccurs="0" name="TotalDeltaTcv" nillable="true" type="decimal" />
+					</sequence>
+				</complexType>
+				<element name="amendResponse">
+					<complexType>
+						<sequence>
+							<element name="results" minOccurs="0" maxOccurs="unbounded" type="zns:AmendResult" />
+						</sequence>
+					</complexType>
+				</element>
+				<complexType name="ExternalPaymentOptions">
+					<sequence>
+						<element minOccurs="0" name="Amount" nillable="true" type="decimal"/>
+						<element minOccurs="0" name="EffectiveDate" nillable="true" type="dateTime" />
+						<element minOccurs="0" name="GatewayOrderId" nillable="true" type="string"/>
+						<element minOccurs="0" name="PaymentMethodId" nillable="true" type="zns:ID" />
+						<element minOccurs="0" name="ReferenceId" nillable="true" type="xs:string" />
+					</sequence>
+				</complexType>
+			
+
+		</schema>
+		<schema attributeFormDefault="qualified" elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://fault.api.zuora.com/">
+		    <import namespace="http://api.zuora.com/" />
+			<complexType name="ApiFault">
+				<sequence>
+					<element minOccurs="0" name="FaultCode" nillable="true" type="zns:ErrorCode" />
+					<element minOccurs="0" name="FaultMessage" nillable="true" type="string" />
+				</sequence>
+			</complexType>
+			<element name="fault" type="fns:ApiFault" />
+			<complexType name="LoginFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="LoginFault" type="fns:LoginFault" />
+			<complexType name="InvalidTypeFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="InvalidTypeFault" type="fns:InvalidTypeFault" />
+			<complexType name="InvalidValueFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="InvalidValueFault" type="fns:InvalidValueFault" />
+			<complexType name="MalformedQueryFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="MalformedQueryFault" type="fns:MalformedQueryFault" />
+			<complexType name="InvalidQueryLocatorFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="InvalidQueryLocatorFault" type="fns:InvalidQueryLocatorFault" />
+			<complexType name="UnexpectedErrorFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="UnexpectedErrorFault" type="fns:UnexpectedErrorFault" />
+		</schema>
+		
+	</types>
+	<message name="ApiFault">
+		<part name="fault" element="fns:fault" />
+	</message>
+	<message name="LoginFault">
+		<part name="fault" element="fns:LoginFault" />
+	</message>
+	<message name="InvalidTypeFault">
+		<part name="fault" element="fns:InvalidTypeFault" />
+	</message>
+	<message name="InvalidValueFault">
+		<part name="fault" element="fns:InvalidValueFault" />
+	</message>
+	<message name="MalformedQueryFault">
+		<part name="fault" element="fns:MalformedQueryFault" />
+	</message>
+	<message name="InvalidQueryLocatorFault">
+		<part name="fault" element="fns:InvalidQueryLocatorFault" />
+	</message>
+	<message name="UnexpectedErrorFault">
+		<part name="fault" element="fns:UnexpectedErrorFault" />
+	</message>
+	<message name="loginRequest">
+		<part name="parameters" element="zns:login" />
+	</message>
+	<message name="loginResponse">
+		<part name="parameters" element="zns:loginResponse" />
+	</message>
+	<message name="subscribeRequest">
+		<part name="parameters" element="zns:subscribe" />
+	</message>
+	<message name="subscribeResponse">
+		<part name="parameters" element="zns:subscribeResponse" />
+	</message>
+	<message name="createRequest">
+		<part name="parameters" element="zns:create" />
+	</message>
+	<message name="createResponse">
+		<part name="parameters" element="zns:createResponse" />
+	</message>
+	<message name="generateRequest">
+		<part name="parameters" element="zns:generate" />
+	</message>
+	<message name="generateResponse">
+		<part name="parameters" element="zns:generateResponse" />
+	</message>
+	<message name="updateRequest">
+		<part name="parameters" element="zns:update" />
+	</message>
+	<message name="updateResponse">
+		<part name="parameters" element="zns:updateResponse" />
+	</message>
+	<message name="deleteRequest">
+		<part name="parameters" element="zns:delete" />
+	</message>
+	<message name="deleteResponse">
+		<part name="parameters" element="zns:deleteResponse" />
+	</message>
+	<message name="executeRequest">
+		<part name="parameters" element="zns:execute" />
+	</message>
+	<message name="executeResponse">
+		<part name="parameters" element="zns:executeResponse" />
+	</message>
+	<message name="queryRequest">
+		<part name="parameters" element="zns:query" />
+	</message>
+	<message name="queryResponse">
+		<part name="parameters" element="zns:queryResponse" />
+	</message>
+
+	    <message name="queryMoreRequest"> 
+	        <part element="zns:queryMore" name="parameters"/> 
+	    </message> 
+	    <message name="queryMoreResponse"> 
+	        <part element="zns:queryMoreResponse" name="parameters"/> 
+	    </message> 
+
+	<message name="Header">
+		<part name="CallOptions" element="zns:CallOptions" />
+		<part name="QueryOptions" element="zns:QueryOptions" />
+		<part name="SessionHeader" element="zns:SessionHeader" />
+	</message>
+	<message name="getUserInfo">
+		<part name="getUserInfo" element="zns:getUserInfo"/>
+	</message>
+	<message name="getUserInfoResponse">
+		<part name="parameters" element="zns:getUserInfoResponse"/>
+	</message>
+		<message name="amendRequest">
+			<part name="parameters" element="zns:amend"/>
+		</message>
+		<message name="amendResponse">
+			<part name="parameters" element="zns:amendResponse"/>
+		</message>
+
+	
+	<portType name="Soap">
+		<operation name="login">
+			<input message="zns:loginRequest" />
+			<output message="zns:loginResponse" />
+			<fault message="zns:LoginFault" name="LoginFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+		<operation name="subscribe">
+			<input message="zns:subscribeRequest" />
+			<output message="zns:subscribeResponse" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+		<operation name="create">
+			<input message="zns:createRequest" />
+			<output message="zns:createResponse" />
+			<fault message="zns:InvalidTypeFault" name="InvalidTypeFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+		<operation name="generate">
+			<input message="zns:generateRequest" />
+			<output message="zns:generateResponse" />
+			<fault message="zns:InvalidTypeFault" name="InvalidTypeFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+		<operation name="update">
+			<input message="zns:updateRequest" />
+			<output message="zns:updateResponse" />
+			<fault message="zns:InvalidTypeFault" name="InvalidTypeFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+		<operation name="delete">
+			<input message="zns:deleteRequest" />
+			<output message="zns:deleteResponse" />
+			<fault message="zns:InvalidTypeFault" name="InvalidTypeFault" />
+			<fault message="zns:InvalidValueFault" name="InvalidValueFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+			<operation name="execute">
+				<input message="zns:executeRequest" />
+				<output message="zns:executeResponse" />
+				<fault message="zns:InvalidTypeFault" name="InvalidTypeFault" />
+				<fault message="zns:InvalidValueFault" name="InvalidValueFault" />
+				<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+			</operation>
+		<operation name="query">
+			<input message="zns:queryRequest" />
+			<output message="zns:queryResponse" />
+			<fault message="zns:MalformedQueryFault" name="MalformedQueryFault" />
+			<fault message="zns:InvalidQueryLocatorFault" name="InvalidQueryLocatorFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+
+        <operation name="queryMore"> 
+            <documentation>Gets the next batch of sObjects from a query</documentation> 
+            <input  message="zns:queryMoreRequest"/> 
+            <output message="zns:queryMoreResponse"/> 
+            <fault  message="zns:InvalidQueryLocatorFault" name="InvalidQueryLocatorFault"/> 
+            <fault  message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault"/> 
+        </operation> 
+
+        <operation name="getUserInfo">
+        	<input message="zns:getUserInfo"/>
+        	<output message="zns:getUserInfoResponse"/>
+        	<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+    	<operation name="amend">
+        	<input message="zns:amendRequest"/>
+        	<output message="zns:amendResponse"/>
+        	<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+	</portType>
+	<binding name="SoapBinding" type="zns:Soap">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<operation name="login">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="LoginFault">
+				<soap:fault name="LoginFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+		<operation name="subscribe">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+		<operation name="create">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="CallOptions" />
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="InvalidTypeFault">
+				<soap:fault name="InvalidTypeFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+		<operation name="generate">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="InvalidTypeFault">
+				<soap:fault name="InvalidTypeFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+		<operation name="update">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="InvalidTypeFault">
+				<soap:fault name="InvalidTypeFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+		<operation name="query">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="QueryOptions"  />
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="MalformedQueryFault">
+				<soap:fault name="MalformedQueryFault" use="literal" />
+			</fault>
+			<fault name="InvalidQueryLocatorFault">
+				<soap:fault name="InvalidQueryLocatorFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+
+        <operation name="queryMore"> 
+            <soap:operation soapAction=""/> 
+            <input> 
+				<soap:header use="literal" message="zns:Header" part="QueryOptions" />
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+            </input> 
+            <output> 
+                <soap:body use="literal"/> 
+            </output> 
+            <fault name="InvalidQueryLocatorFault"> 
+                <soap:fault name="InvalidQueryLocatorFault" use="literal"/> 
+            </fault> 
+            <fault name="UnexpectedErrorFault"> 
+                <soap:fault name="UnexpectedErrorFault" use="literal"/> 
+            </fault> 
+        </operation>
+
+		<operation name="delete">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="InvalidTypeFault">
+				<soap:fault name="InvalidTypeFault" use="literal" />
+			</fault>
+			<fault name="InvalidValueFault">
+				<soap:fault name="InvalidValueFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+        <operation name="getUserInfo">
+			<soap:operation soapAction=""/>
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal"/>
+			</input>
+			<output>
+				<soap:body use="literal"/>
+			</output>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal"/>
+			</fault>
+        </operation>
+    	<operation name="amend">
+			<soap:operation soapAction=""/>
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal"/>
+			</input>
+			<output>
+				<soap:body use="literal"/>
+			</output>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal"/>
+			</fault>
+        </operation>
+    	<operation name="execute">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="InvalidTypeFault">
+				<soap:fault name="InvalidTypeFault" use="literal" />
+			</fault>
+			<fault name="InvalidValueFault">
+				<soap:fault name="InvalidValueFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+	</binding>
+	<service name="ZuoraService">
+		<port name="Soap" binding="zns:SoapBinding">
+			<soap:address location="https://apisandbox.zuora.com/apps/services/a/64.0" />
+		</port>
+	</service>
+</definitions>

--- a/zuora/zuora.a.64.0.wsdl
+++ b/zuora/zuora.a.64.0.wsdl
@@ -1,0 +1,1833 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright Zuora, Inc. 2007 - 2010 All Rights Reserved. -->
+
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" 
+	xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" 
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+	xmlns:zns="http://api.zuora.com/" 
+	xmlns:ons="http://object.api.zuora.com/"
+	xmlns:fns="http://fault.api.zuora.com/"
+	targetNamespace="http://api.zuora.com/">
+	<types>
+		<schema attributeFormDefault="qualified" elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://object.api.zuora.com/">
+		    <import namespace="http://api.zuora.com/" />
+            <complexType name="zObject">
+				<sequence>
+					<element minOccurs="0" maxOccurs="unbounded" name="fieldsToNull" nillable="true" type="string" />
+					<element minOccurs="0" maxOccurs="1" name="Id" nillable="true" type="zns:ID" />
+				</sequence>
+			</complexType>
+			
+	
+	<complexType name="AccountingCode">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+					       	<element minOccurs="0" name="Category" nillable="true" type="string" />
+					       	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+					       	<element minOccurs="0" name="GLAccountName" nillable="true" type="string"   />
+					       	<element minOccurs="0" name="GLAccountNumber" nillable="true" type="string"   />
+					        <element minOccurs="0" name="Name" nillable="false" type="string" />
+					       	<element minOccurs="0" name="Notes" nillable="true" type="string" />
+					       	<element minOccurs="0" name="Status" nillable="true" type="string" />
+					       	<element minOccurs="0" name="Type" nillable="false" type="string" />
+					       	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+						</sequence>
+					</extension>
+				</complexContent>
+		</complexType>
+	
+	<complexType name="AccountingPeriod">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+					       	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+					       	<element minOccurs="0" name="EndDate" nillable="true" type="dateTime" />
+					       	<element minOccurs="0" name="FiscalYear" nillable="true" type="int" />
+					        <element minOccurs="0" name="Name" nillable="true" type="string" />
+					       	<element minOccurs="0" name="Notes" nillable="true" type="string" />
+					        <element minOccurs="0" name="StartDate" nillable="true" type="dateTime" />
+					       	<element minOccurs="0" name="Status" nillable="true" type="string" />
+					       	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+						</sequence>
+					</extension>
+				</complexContent>
+		</complexType>
+			<complexType name="Account" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="AdditionalEmailAddresses" nillable="true" type="string" />
+							<element minOccurs="0" name="AllowInvoiceEdit" nillable="true" type="boolean"  />
+							<element minOccurs="0" name="AutoPay" nillable="true" type="boolean" />
+							<element minOccurs="0" name="Balance" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Batch" nillable="true" type="string" />
+							<element minOccurs="0" name="BcdSettingOption" nillable="true" type="string" />
+							<element minOccurs="0" name="BillCycleDay" type="int" />
+							<element minOccurs="0" name="BillToId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="CommunicationProfileId" nillable="true" type="zns:ID" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="CrmId" nillable="true" type="string" />
+							<element minOccurs="0" name="Currency" nillable="true" type="string" />
+							<element minOccurs="0" name="CustomerServiceRepName" nillable="true" type="string" />
+							<element minOccurs="0" name="DefaultPaymentMethodId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="InvoiceDeliveryPrefsEmail" nillable="true" type="boolean" />
+							<element minOccurs="0" name="InvoiceDeliveryPrefsPrint" nillable="true" type="boolean" />
+							<element minOccurs="0" name="InvoiceTemplateId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="LastInvoiceDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="Notes" nillable="true" type="string" />
+							<element minOccurs="0" name="PaymentGateway" nillable="true" type="string"  />
+							<element minOccurs="0" name="PaymentTerm" nillable="true" type="string" /><!-- user-defined enum -->
+							<element minOccurs="0" name="PurchaseOrderNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="SalesRepName" nillable="true" type="string" />
+							<element minOccurs="0" name="SoldToId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			
+<complexType name="InvoiceItemAdjustment" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="AdjustmentDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="AdjustmentNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="Amount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="CancelledById" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="CancelledDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Comment" nillable="true" type="string" />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="CustomerName" nillable="true" type="string" />
+							<element minOccurs="0" name="CustomerNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="InvoiceItemName" nillable="true" type="string" />
+							<element minOccurs="0" name="InvoiceNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="ReasonCode" nillable="true" type="string" />
+							<element minOccurs="0" name="ReferenceId" nillable="true" type="string" />
+							<element minOccurs="0" name="ServiceEndDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ServiceStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="SourceId" nillable="true" type="string" />
+							<element minOccurs="0" name="SourceType" nillable="true" type="string" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="TransferredToAccounting" nillable="true" type="string" />
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>	
+
+			<complexType name="Amendment">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AutoRenew" nillable="true" type="boolean"  />
+							<element minOccurs="0" name="Code" nillable="true" type="string" />
+							<element minOccurs="0" name="ContractEffectiveDate" nillable="true" type="dateTime" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+               				<element minOccurs="0" name="CustomerAcceptanceDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="EffectiveDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="InitialTerm" nillable="true" type="long" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="RatePlanData" nillable="true" type="zns:RatePlanData" />
+               				<element minOccurs="0" name="RenewalSetting" nillable="true" type="string" />
+							<element minOccurs="0" name="RenewalTerm" nillable="true" type="long" />
+							<element minOccurs="0" name="ServiceActivationDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="TermStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TermType" nillable="true" type="string"  />
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Contact">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="Address1" nillable="true" type="string" />
+							<element minOccurs="0" name="Address2" nillable="true" type="string" />
+							<element minOccurs="0" name="City" nillable="true" type="string" />
+							<element minOccurs="0" name="Country" nillable="true" type="string" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Fax" nillable="true" type="string" />
+							<element minOccurs="0" name="FirstName" nillable="true" type="string" />
+							<element minOccurs="0" name="HomePhone" nillable="true" type="string" />
+							<element minOccurs="0" name="LastName" nillable="true" type="string" />
+							<element minOccurs="0" name="MobilePhone" nillable="true" type="string" />
+							<element minOccurs="0" name="NickName" nillable="true" type="string" />
+							<element minOccurs="0" name="OtherPhone" nillable="true" type="string" />
+							<element minOccurs="0" name="OtherPhoneType" nillable="true" type="string" />
+							<element minOccurs="0" name="PersonalEmail" nillable="true" type="string" />
+							<element minOccurs="0" name="PostalCode" nillable="true" type="string" />
+							<element minOccurs="0" name="State" nillable="true" type="string" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+              				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="WorkEmail" nillable="true" type="string" />
+							<element minOccurs="0" name="WorkPhone" nillable="true" type="string" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Invoice" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AdjustmentAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Amount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Balance" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Body" nillable="true" type="string" />
+							<element minOccurs="0" name="Comments" nillable="true" type="string" />
+							<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="DueDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="IncludesOneTime" nillable="true" type="boolean" />
+							<element minOccurs="0" name="IncludesRecurring" nillable="true" type="boolean" />
+							<element minOccurs="0" name="IncludesUsage" nillable="true" type="boolean" />
+							<element minOccurs="0" name="InvoiceDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="InvoiceNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="LastEmailSentDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="PaymentAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="PostedBy" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="PostedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="RefundAmount" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="RegenerateInvoicePDF" nillable="true" type="boolean"  />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="TargetDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TransferredToAccounting" nillable="true" type="string" />
+							<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Refund" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="Amount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="CancelledOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Comment" nillable="true" type="string" />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Gateway" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayOptionData" nillable="true" type="zns:GatewayOptionData" />
+							<element minOccurs="0" name="GatewayResponse" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayResponseCode" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayState" nillable="true" type="string" />
+							<element minOccurs="0" name="MarkedForSubmissionOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="MethodType" nillable="true" type="string" />
+							<element minOccurs="0" name="PaymentId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="PaymentMethodId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="PaymentMethodSnapshotId" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="ReasonCode" nillable="true" type="string" />
+							<element minOccurs="0" name="ReferenceID" nillable="true" type="string" />
+							<element minOccurs="0" name="RefundDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="RefundInvoicePaymentData" nillable="true" type="zns:RefundInvoicePaymentData" />
+							<element minOccurs="0" name="RefundNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="RefundTransactionTime" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="SecondRefundReferenceId" nillable="true" type="string" />
+							<element minOccurs="0" name="SettledOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="SoftDescriptor" nillable="true" type="string" />
+							<element minOccurs="0" name="SoftDescriptorPhone" nillable="true" type="string" />
+							<element minOccurs="0" name="SourceType" nillable="true" type="string" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="SubmittedOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TransferredToAccounting" nillable="true" type="string" />
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+			                <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+			                <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="RefundInvoicePayment">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="InvoicePaymentId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RefundAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="RefundId" nillable="true" type="zns:ID" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="RefundTransactionLog">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="BatchId" nillable="true" type="string" />
+							<element minOccurs="0" name="Gateway" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayReasonCode" nillable="true" type="string"/>
+							<element minOccurs="0" name="GatewayReasonCodeDescription" nillable="true" type="string"/>
+							<element minOccurs="0" name="GatewayState" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayTransactionType" nillable="true" type="string" />
+							<element minOccurs="0" name="RefundId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RequestString" nillable="true" type="string"/>
+							<element minOccurs="0" name="ResponseString" nillable="true" type="string"/>
+							<element minOccurs="0" name="TransactionDate" nillable="true" type="dateTime" />
+               				<element minOccurs="0" name="TransactionId" nillable="true" type="string"/>
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="InvoiceItem" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+                            <element minOccurs="0" name="AppliedToInvoiceItemId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="ChargeAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="ChargeDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ChargeDescription" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeId" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeName" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeType" nillable="true" type="string" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="ProcessingType" nillable="true" type="decimal"/>
+							<element minOccurs="0" name="ProductDescription" nillable="true" type="string" />
+							<element minOccurs="0" name="ProductId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="ProductName" nillable="true" type="string" />
+							<element minOccurs="0" name="Quantity" nillable="true" type="decimal" />
+							<element minOccurs="0" name="RatePlanChargeId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RevRecCode" nillable="true" type="string" />
+							<element minOccurs="0" name="RevRecStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="RevRecTriggerCondition" nillable="true" type="string" />
+							<element minOccurs="0" name="ServiceEndDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ServiceStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="SKU" nillable="true" type="string" />
+							<element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="SubscriptionNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="UnitPrice" nillable="true" type="decimal" />
+							<element minOccurs="0" name="UOM" nillable="true" type="string" />
+              				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="InvoicePayment">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="Amount" nillable="true" type="decimal" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="PaymentId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RefundAmount" nillable="true" type="decimal" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Payment" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="Amount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="AuthTransactionId" nillable="true" type="string" />
+							<element minOccurs="0" name="BankIdentificationNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="CancelledOn" nillable="true" type="dateTime"/>
+							<element minOccurs="0" name="Comment" nillable="true" type="string" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="EffectiveDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Gateway" nillable="true" type="string"  />
+							<element minOccurs="0" name="GatewayOptionData" nillable="true" type="zns:GatewayOptionData" />
+							<element minOccurs="0" name="GatewayOrderId" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayResponse" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayResponseCode" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayState" nillable="true" type="string" />
+							<element minOccurs="0" name="InvoicePaymentData" nillable="true" type="zns:InvoicePaymentData" />
+							<element minOccurs="0" name="MarkedForSubmissionOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="PaymentMethodId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="PaymentMethodSnapshotId" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="PaymentNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="ReferenceId" nillable="true" type="string" />
+							<element minOccurs="0" name="RefundAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="SecondPaymentReferenceId" nillable="true" type="string" />
+							<element minOccurs="0" name="SettledOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="SoftDescriptor" nillable="true" type="string" />
+							<element minOccurs="0" name="SoftDescriptorPhone" nillable="true" type="string" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="SubmittedOn" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TransferredToAccounting" nillable="true" type="string" />
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+               			    <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               			    <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="PaymentTransactionLog">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AVSResponseCode" nillable="true" type="string"/>
+							<element minOccurs="0" name="BatchId" nillable="true" type="string" />
+                            <element minOccurs="0" name="CVVResponseCode" nillable="true" type="string"/>
+                            <element minOccurs="0" name="Gateway" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayReasonCode" nillable="true" type="string"/>
+							<element minOccurs="0" name="GatewayReasonCodeDescription" nillable="true" type="string"/>
+							<element minOccurs="0" name="GatewayState" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayTransactionType" nillable="true" type="string"/>
+							<element minOccurs="0" name="PaymentId" nillable="true" type="zns:ID"/>
+							<element minOccurs="0" name="RequestString" nillable="true" type="string"/>
+							<element minOccurs="0" name="ResponseString" nillable="true" type="string"/>
+							<element minOccurs="0" name="TransactionDate" nillable="true" type="dateTime" />
+               				<element minOccurs="0" name="TransactionId" nillable="true" type="string"/>
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="PaymentMethod">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AchAbaCode" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountName" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountNumberMask" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountType" nillable="true" type="string" />
+							<element minOccurs="0" name="AchBankName" nillable="true" type="string" />
+							<element minOccurs="0" name="Active" nillable="true" type="boolean" />
+							<element minOccurs="0" name="BankIdentificationNumber" nillable="true" type="string" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="CreditCardAddress1" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardAddress2" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardCity" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardCountry" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardExpirationMonth" nillable="true" type="int" />
+							<element minOccurs="0" name="CreditCardExpirationYear" nillable="true" type="int" />
+							<element minOccurs="0" name="CreditCardHolderName" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardMaskNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardPostalCode" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardSecurityCode" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardState" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardType" nillable="true" type="string" />
+							<element minOccurs="0" name="DeviceSessionId" nillable="true" type="string" />
+							<element minOccurs="0" name="Email" nillable="true" type="string" />
+							<element minOccurs="0" name="GatewayOptionData" nillable="true" type="zns:GatewayOptionData" />
+							<element minOccurs="0" name="IPAddress" nillable="true" type="string" />
+							<element minOccurs="0" name="LastFailedSaleTransactionDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="LastTransactionDateTime" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="LastTransactionStatus" nillable="true" type="string" />
+							<element minOccurs="0" name="MaxConsecutivePaymentFailures" nillable="true" type="short" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="NumConsecutiveFailures" nillable="true" type="int" />
+							<element minOccurs="0" name="PaymentMethodStatus" nillable="true" type="string"/>
+							<element minOccurs="0" name="PaymentRetryWindow" nillable="true" type="short" />
+							<element minOccurs="0" name="PaypalBaid" nillable="true" type="string" /> 
+							<element minOccurs="0" name="PaypalEmail" nillable="true" type="string" />
+							<element minOccurs="0" name="PaypalPreapprovalKey" nillable="true" type="string" />
+							<element minOccurs="0" name="PaypalType" nillable="true" type="string" />
+							<element minOccurs="0" name="Phone" nillable="true" type="string" />
+							<element minOccurs="0" name="SecondTokenId" nillable="true" type="string" />
+							<element minOccurs="0" name="SkipValidation" nillable="true" type="boolean" />
+							<element minOccurs="0" name="TokenId" nillable="true" type="string" />
+							<element minOccurs="0" name="TotalNumberOfErrorPayments" nillable="true" type="int"/>
+							<element minOccurs="0" name="TotalNumberOfProcessedPayments" nillable="true" type="int"/>
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+               				<element minOccurs="0" name="UseDefaultRetryRule" nillable="true" type="boolean" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+            <complexType name="PaymentMethodTransactionLog">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>							    
+						    <element minOccurs="0" name="Gateway" nillable="true" type="string" />								   						
+							<element minOccurs="0" name="GatewayReasonCode" nillable="true" type="string"/>
+							<element minOccurs="0" name="GatewayReasonCodeDescription" nillable="true" type="string"/>	
+							<element minOccurs="0" name="GatewayTransactionType" nillable="true" type="string"/>													
+							<element minOccurs="0" name="PaymentMethodId" nillable="true" type="string"/>	
+							<element minOccurs="0" name="PaymentMethodType" nillable="true" type="string"/>												
+							<element minOccurs="0" name="RequestString" nillable="true" type="string"/>
+							<element minOccurs="0" name="ResponseString" nillable="true" type="string"/>
+							<element minOccurs="0" name="TransactionDate" nillable="true" type="string"/>							
+               				<element minOccurs="0" name="TransactionId" nillable="true" type="string"/>              				
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+		<complexType name="PaymentMethodSnapshot">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AchAbaCode" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountName" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountNumberMask" nillable="true" type="string" />
+							<element minOccurs="0" name="AchAccountType" nillable="true" type="string" />
+							<element minOccurs="0" name="AchBankName" nillable="true" type="string" />
+							<element minOccurs="0" name="BankBranchCode" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankCheckDigit" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankCity" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankCode" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankIdentificationNumber" nillable="true" type="string"/>
+			               	<element minOccurs="0" name="BankName" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="BankPostalCode" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="BankStreetName" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="BankStreetNumber" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="BankTransferAccountName" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankTransferAccountNumber" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankTransferAccountNumberMask" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BankTransferAccountType" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="BankTransferType" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="BusinessIdentificationCode" nillable="true" type="string"/> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="City" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+			               	<element minOccurs="0" name="Country" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="CreditCardAddress1" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardAddress2" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardCity" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardCountry" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardExpirationMonth" nillable="true" type="int" />
+							<element minOccurs="0" name="CreditCardExpirationYear" nillable="true" type="int" />
+							<element minOccurs="0" name="CreditCardHolderName" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardMaskNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardPostalCode" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardState" nillable="true" type="string" />
+							<element minOccurs="0" name="CreditCardType" nillable="true" type="string" />
+							<element minOccurs="0" name="DeviceSessionId" nillable="true" type="string" />
+							<element minOccurs="0" name="Email" nillable="true" type="string"/>
+							<element minOccurs="0" name="ExistingMandate" nillable="true" type="string"/> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="FirstName" nillable="true" type="string"/> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="IBAN" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="IPAddress" nillable="true" type="string"/>
+							<element minOccurs="0" name="LastFailedSaleTransactionDate" nillable="true" type="dateTime"/>
+							<element minOccurs="0" name="LastName" nillable="true" type="string"/> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="LastTransactionDateTime" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="LastTransactionStatus" nillable="true" type="string" />
+							<element minOccurs="0" name="MandateCreationDate" nillable="true" type="dateTime" /> <!-- this field use for bank transfer payment method -->
+        					<element minOccurs="0" name="MandateID" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+        					<element minOccurs="0" name="MandateReceived" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+        					<element minOccurs="0" name="MandateUpdateDate" nillable="true" type="dateTime" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="MaxConsecutivePaymentFailures" nillable="true" type="short" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="NumConsecutiveFailures" nillable="true" type="int"/>
+							<element minOccurs="0" name="PaymentMethodId" nillable="true" type="zns:ID"/>
+							<element minOccurs="0" name="PaymentMethodStatus" nillable="true" type="string"/>
+							<element minOccurs="0" name="PaymentRetryWindow" nillable="true" type="short"/>
+							<element minOccurs="0" name="PaypalBaid" nillable="true" type="string" /> 
+							<element minOccurs="0" name="PaypalEmail" nillable="true" type="string" />
+							<element minOccurs="0" name="PaypalPreapprovalKey" nillable="true" type="string" />
+							<element minOccurs="0" name="PaypalType" nillable="true" type="string" />
+							<element minOccurs="0" name="Phone" nillable="true" type="string" />
+							<element minOccurs="0" name="PostalCode" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="SecondTokenId" nillable="true" type="string"/>
+							<element minOccurs="0" name="State" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="StreetName" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="StreetNumber" nillable="true" type="string" /> <!-- this field use for bank transfer payment method -->
+							<element minOccurs="0" name="TokenId" nillable="true" type="string"/>
+							<element minOccurs="0" name="TotalNumberOfErrorPayments" nillable="true" type="int"/>
+							<element minOccurs="0" name="TotalNumberOfProcessedPayments" nillable="true" type="int"/>
+							<element minOccurs="0" name="Type" nillable="true" type="string" />
+			               	<element minOccurs="0" name="UseDefaultRetryRule" nillable="true" type="boolean" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Product" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+						  <element minOccurs="0" name="AllowFeatureChanges" nillable="true" type="boolean" />
+							<element minOccurs="0" name="Category" nillable="true" type="string" />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="EffectiveEndDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="EffectiveStartDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="SKU" nillable="true" type="string" />
+			               	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+      <complexType name="Feature" >
+        <complexContent>
+          <extension base="ons:zObject">
+            <sequence>
+              <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+              <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"/>
+              <element minOccurs="0" name="Description" nillable="true" type="string" />
+              <element minOccurs="0" name="FeatureCode" nillable="false" type="string" />
+              <element minOccurs="0" name="Name" nillable="false" type="string" />
+              <element minOccurs="0" name="Status" nillable="true" type="string" />
+              <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+              <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+            </sequence>
+          </extension>
+        </complexContent>
+      </complexType>
+      <complexType name="ProductFeature" >
+        <complexContent>
+          <extension base="ons:zObject">
+            <sequence>
+              <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+              <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"/>
+              <element minOccurs="0" name="FeatureId" nillable="false" type="zns:ID" />
+              <element minOccurs="0" name="ProductId" nillable="false" type="zns:ID" />
+              <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+              <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+            </sequence>
+          </extension>
+        </complexContent>
+      </complexType>
+			<complexType name="ProductRatePlan" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+			               	<element minOccurs="0" name="ActiveCurrencies" nillable="true" type="string"  />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="EffectiveEndDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="EffectiveStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="ProductId" nillable="true" type="zns:ID" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="ProductRatePlanCharge" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="ApplyDiscountTo" nillable="true" type="string"  />
+							<element minOccurs="0" name="BillCycleDay" nillable="true" type="int" />
+							<element minOccurs="0" name="BillCycleType" nillable="true" type="string" />
+							<element minOccurs="0" name="BillingPeriod" nillable="true" type="string"  />
+							<element minOccurs="0" name="BillingPeriodAlignment" nillable="true" type="string" />
+               				<element minOccurs="0" name="ChargeModel" nillable="true" type="string"  />
+							<element minOccurs="0" name="ChargeType" nillable="true" type="string"  />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="DefaultQuantity" nillable="true" type="decimal" />
+							<element minOccurs="0" name="DeferredRevenueAccount" nillable="true" type="string"   />
+							<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="DiscountLevel" nillable="true" type="string" />
+							<element minOccurs="0" name="IncludedUnits" nillable="true" type="decimal" />
+							<element minOccurs="0" name="LegacyRevenueReporting" nillable="true" type="boolean" />
+							<element minOccurs="0" name="MaxQuantity" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="MinQuantity" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="NumberOfPeriod" nillable="true" type="long"  />
+							<element minOccurs="0" name="OverageCalculationOption" nillable="true" type="string"  />
+							<element minOccurs="0" name="OverageUnusedUnitsCreditOption" nillable="true" type="string"  />
+							<element minOccurs="0" name="PriceChangeOption" nillable="true" type="string" />
+							<element minOccurs="0" name="PriceIncreasePercentage" nillable="true" type="decimal" />
+							<element minOccurs="0" name="ProductRatePlanChargeTierData" nillable="true" type="zns:ProductRatePlanChargeTierData"  />
+							<element minOccurs="0" name="ProductRatePlanId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RecognizedRevenueAccount" nillable="true" type="string"  />
+							<element minOccurs="0" name="RevenueRecognitionRuleName" nillable="true" type="string"  />
+							<element minOccurs="0" name="RevRecCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="RevRecTriggerCondition" nillable="true" type="string"  />
+							<element minOccurs="0" name="SmoothingModel" nillable="true" type="string"  />
+							<element minOccurs="0" name="SpecificBillingPeriod" nillable="true" type="long" />
+							<element minOccurs="0" name="TriggerEvent" nillable="true" type="string" />
+							<element minOccurs="0" name="UOM" nillable="true" type="string" />
+			               	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+			               	<element minOccurs="0" name="UpToPeriods" nillable="true" type="long"  />
+			               	<element minOccurs="0" name="UsageRecordRatingOption" nillable="true" type="string"  />
+			               	<element minOccurs="0" name="UseDiscountSpecificAccountingCode" nillable="true" type="boolean" />
+							<element minOccurs="0" name="UseTenantDefaultForPriceChange" nillable="true" type="boolean" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="ProductRatePlanChargeTier">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Currency" nillable="true" type="string" />
+							<element minOccurs="0" name="DiscountAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="DiscountPercentage" nillable="true" type="decimal" />
+							<element minOccurs="0" name="EndingUnit" nillable="true" type="decimal" />
+							<element minOccurs="0" name="IsOveragePrice" nillable="true" type="boolean"  />
+							<element minOccurs="0" name="Price" nillable="true" type="decimal" />
+							<element minOccurs="0" name="PriceFormat" nillable="true" type="string" />
+							<element minOccurs="0" name="ProductRatePlanChargeId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="StartingUnit" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Tier" nillable="true" type="int" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="GatewayOption" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="name" nillable="true" type="string" />
+							<element minOccurs="0" name="value" nillable="true" type="string" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="RatePlan">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AmendmentId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AmendmentSubscriptionRatePlanId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AmendmentType" nillable="true" type="string" />
+               				<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Name" nillable="true" type="string" /><!-- do we need this? -->
+							<element minOccurs="0" name="ProductRatePlanId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="SubscriptionProductFeature" >
+		        <complexContent>
+		          <extension base="ons:zObject">
+		            <sequence>
+		              <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+		              <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+		              <element minOccurs="0" name="Description" nillable="true" type="string" />
+		              <element minOccurs="0" name="FeatureCode" nillable="true" type="string" />
+		              <element minOccurs="0" name="FeatureId" nillable="false" type="zns:ID" />
+		              <element minOccurs="0" name="Name" nillable="true" type="string" />
+		              <element minOccurs="0" name="RatePlanId" nillable="true" type="zns:ID" />
+		              <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+		              <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+		            </sequence>
+		          </extension>
+		        </complexContent>
+		      </complexType>
+			<complexType name="RatePlanCharge" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountingCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="ApplyDiscountTo" nillable="true" type="string" />
+							<element minOccurs="0" name="BillCycleDay" nillable="true" type="int" />
+							<element minOccurs="0" name="BillCycleType" nillable="true" type="string" />
+							<element minOccurs="0" name="BillingPeriod" nillable="true" type="string" />
+							<element minOccurs="0" name="BillingPeriodAlignment" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargedThroughDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ChargeModel" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeNumber" nillable="true" type="string" />
+							<element minOccurs="0" name="ChargeType" nillable="true" type="string" />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="DiscountAmount" nillable="true" type="decimal" />
+							<element minOccurs="0" name="DiscountLevel" nillable="true" type="string" />
+							<element minOccurs="0" name="DiscountPercentage" nillable="true" type="decimal" />
+							<element minOccurs="0" name="DMRC" nillable="true" type="decimal" />
+							<element minOccurs="0" name="DTCV" nillable="true" type="decimal" />
+							<element minOccurs="0" name="EffectiveEndDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="EffectiveStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="IncludedUnits" nillable="true" type="decimal" />
+							<element minOccurs="0" name="IsLastSegment" nillable="true" type="boolean"  />
+							<element minOccurs="0" name="MRR" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="NumberOfPeriods" nillable="true" type="long" />
+							<element minOccurs="0" name="OriginalId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="OverageCalculationOption" nillable="true" type="string"  />
+							<element minOccurs="0" name="OveragePrice" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="OverageUnusedUnitsCreditOption" nillable="true" type="string"  />
+							<element minOccurs="0" name="Price" nillable="true" type="decimal" />
+							<element minOccurs="0" name="PriceChangeOption" nillable="true" type="string" />
+							<element minOccurs="0" name="PriceIncreasePercentage" nillable="true" type="decimal" />
+							<element minOccurs="0" name="ProcessedThroughDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ProductRatePlanChargeId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="Quantity" nillable="true" type="decimal" />
+							<element minOccurs="0" name="RatePlanId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="RevRecCode" nillable="true" type="string"  />
+							<element minOccurs="0" name="RevRecTriggerCondition" nillable="true" type="string"  />
+							<element minOccurs="0" name="RolloverBalance" nillable="true" type="decimal" />
+							<element minOccurs="0" name="Segment" nillable="true" type="int" />
+							<element minOccurs="0" name="SpecificBillingPeriod" nillable="true" type="long" />
+							<element minOccurs="0" name="TCV" nillable="true" type="decimal" />
+							<element minOccurs="0" name="TriggerDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TriggerEvent" nillable="true" type="string" />
+							<element minOccurs="0" name="UnusedUnitsCreditRates" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="UOM" nillable="true" type="string" />
+			               	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+			               	<element minOccurs="0" name="UpToPeriods" nillable="true" type="long"  />
+							<element minOccurs="0" name="UsageRecordRatingOption" nillable="true" type="string"  />
+			               	<element minOccurs="0" name="UseDiscountSpecificAccountingCode" nillable="true" type="boolean"  />
+			               	<element minOccurs="0" name="Version" nillable="true" type="long" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="RatePlanChargeTier">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="EndingUnit" nillable="true" type="decimal" />
+							<element minOccurs="0" name="IsOveragePrice" nillable="true" type="boolean" />
+							<element minOccurs="0" name="Price" nillable="true" type="decimal" />
+							<element minOccurs="0" name="PriceFormat" nillable="true" type="string" />
+							<element minOccurs="0" name="RatePlanChargeId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="StartingUnit" nillable="true" type="decimal"  />
+							<element minOccurs="0" name="Tier" nillable="true" type="int" />
+               				<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+               				<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+			<complexType name="Subscription" >
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+							<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+							<element minOccurs="0" name="AutoRenew" nillable="true" type="boolean" />
+							<element minOccurs="0" name="CancelledDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ContractAcceptanceDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="ContractEffectiveDate" nillable="true" type="dateTime" />
+			               	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="InitialTerm" nillable="true" type="int" />
+							<element minOccurs="0" name="IsInvoiceSeparate" nillable="true" type="boolean" />
+							<element minOccurs="0" name="Name" nillable="true" type="string" />
+							<element minOccurs="0" name="Notes" nillable="true" type="string" />
+                     		<element minOccurs="0" name="OriginalCreatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="OriginalId" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="PreviousSubscriptionId" nillable="true" type="zns:ID"  />
+							<element minOccurs="0" name="RenewalSetting" nillable="true" type="string" />
+							<element minOccurs="0" name="RenewalTerm" nillable="true" type="int" />
+							<element minOccurs="0" name="ServiceActivationDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="Status" nillable="true" type="string" />
+							<element minOccurs="0" name="SubscriptionEndDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="SubscriptionStartDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="TermEndDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TermStartDate" nillable="true" type="dateTime" />
+							<element minOccurs="0" name="TermType" nillable="true" type="string" />
+			               	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+			               	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+							<element minOccurs="0" name="Version" nillable="true" type="int" />
+						</sequence>
+					</extension>
+				</complexContent>
+			</complexType>
+
+	   		 <complexType name="Usage" >
+	    		<complexContent>
+	    		 <extension base="ons:zObject">
+	     			 <sequence>
+		      			 <element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+		      			 <element minOccurs="0" name="AccountNumber" nillable="true" type="string" />
+		      			 <element minOccurs="0" name="ChargeId" nillable="true" type="zns:ID" />
+		      			 <element minOccurs="0" name="ChargeNumber" nillable="true" type="string"/>
+		               	 <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"  />
+		                 <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"  />
+		      			 <element minOccurs="0" name="Description" nillable="true" type="string" />
+		    			 <element minOccurs="0" name="EndDateTime" nillable="true" type="dateTime" />
+                         <element minOccurs="0" name="ImportId" nillable="true" type="zns:ID" />
+		    			 <element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+		    			 <element minOccurs="0" name="InvoiceNumber" nillable="true" type="string" />
+		       			 <element minOccurs="0" name="Quantity" nillable="true" type="decimal" />
+		       			 <element minOccurs="0" name="RbeStatus" nillable="true" type="string"/>
+		    			 <element minOccurs="0" name="SourceName" nillable="true" type="string" />
+		        		 <element minOccurs="0" name="SourceType" nillable="true" type="string"/>		       			 
+		       			 <element minOccurs="0" name="StartDateTime" nillable="true" type="dateTime" />
+		       			 <element minOccurs="0" name="SubmissionDateTime" nillable="true" type="dateTime" />
+		       			 <element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+		       			 <element minOccurs="0" name="SubscriptionNumber" nillable="true" type="string"/>
+		       			 <element minOccurs="0" name="UOM" nillable="true" type="string" />
+		                 <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"  />
+		                 <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"  />
+	                 </sequence>
+	            </extension>
+	           </complexContent>
+	   		</complexType>
+          <complexType name="Import">
+            <complexContent>
+             <extension base="ons:zObject">
+                 <sequence>
+                     <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"/>
+                     <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"/>
+                     <element minOccurs="0" name="FileContent" nillable="true" type="xs:base64Binary"/>
+                     <element minOccurs="0" name="ImportedCount" nillable="true" type="xs:int"/>
+                     <element minOccurs="0" name="ImportType" nillable="true" type="string"/>
+                     <element minOccurs="0" name="Md5" nillable="true" type="string"/>
+                     <element minOccurs="0" name="Name" nillable="true" type="string"/>
+                     <element minOccurs="0" name="OriginalResourceUrl" nillable="true" type="string"/>
+                     <element minOccurs="0" name="ResultResourceUrl" nillable="true" type="string"/>
+                     <element minOccurs="0" name="Status" nillable="true" type="string"/>
+                     <element minOccurs="0" name="StatusReason" nillable="true" type="string"/>
+                     <element minOccurs="0" name="TotalCount" nillable="true" type="xs:int"/>
+                     <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"/>
+                     <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"/>
+                 </sequence>
+               </extension>
+              </complexContent>
+            </complexType>
+          <complexType name="Export">
+            <complexContent>
+             <extension base="ons:zObject">
+                <sequence>
+                      <element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID"/>
+                      <element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime"/>
+                      <element minOccurs="0" name="Encrypted" nillable="true" type="xs:boolean" />
+                      <element minOccurs="0" name="FileId" nillable="true" type="zns:ID"/>
+                      <element minOccurs="0" name="Format" nillable="true" type="string"/>
+                      <element minOccurs="0" name="Name" nillable="true" type="string" />
+                      <element minOccurs="0" name="Query" nillable="true" type="string"/>
+                      <element minOccurs="0" name="Size" nillable="true" type="xs:int"/>
+                      <element minOccurs="0" name="Status" nillable="true" type="string"/>
+                      <element minOccurs="0" name="StatusReason" nillable="true" type="string"/>
+                      <element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID"/>
+                      <element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime"/>
+                      <element minOccurs="0" name="Zip" nillable="true" type="xs:boolean"/>
+                    </sequence>
+               </extension>
+              </complexContent>
+            </complexType>
+          <complexType name="CommunicationProfile">
+				<complexContent>
+					<extension base="ons:zObject">
+						<sequence>
+					       	<element minOccurs="0" name="CreatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="CreatedDate" nillable="true" type="dateTime" />
+					       	<element minOccurs="0" name="Description" nillable="true" type="string" />
+							<element minOccurs="0" name="ProfileName" nillable="true" type="string" />
+					       	<element minOccurs="0" name="UpdatedById" nillable="true" type="zns:ID" />
+					       	<element minOccurs="0" name="UpdatedDate" nillable="true" type="dateTime" />
+						</sequence>
+					</extension>
+				</complexContent>
+		  </complexType>
+
+		
+
+
+		
+				
+   		</schema>
+		<schema attributeFormDefault="qualified" elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://api.zuora.com/">
+		<import namespace="http://object.api.zuora.com/" />
+			<simpleType name="ID">
+				<restriction base="xs:string">
+					<pattern value='[a-zA-Z0-9]{32}|\d+' />
+				</restriction>
+			</simpleType>
+			<complexType name="LoginResult">
+				<sequence>
+					<element name="Session" nillable="true" type="xs:string" />
+					<element name="ServerUrl" nillable="true" type="xs:string" />
+				</sequence>
+			</complexType>
+			<complexType name="SubscribeRequest">
+				<sequence>
+					<element minOccurs="0" name="Account" nillable="true" type="ons:Account" />
+					<element minOccurs="0" name="PaymentMethod" nillable="true" type="ons:PaymentMethod" />
+					<element minOccurs="0" name="BillToContact" nillable="true" type="ons:Contact" />
+					<element minOccurs="0" name="PreviewOptions" nillable="true" type="zns:PreviewOptions"  />
+					<element minOccurs="0" name="SoldToContact" nillable="true" type="ons:Contact" />
+					<element minOccurs="0" name="SubscribeOptions" nillable="true" type="zns:SubscribeOptions" />
+					<element minOccurs="0" name="SubscriptionData" nillable="true" type="zns:SubscriptionData" />
+				</sequence>
+			</complexType>
+			<complexType name="SubscribeOptions">
+				<sequence>
+					<element minOccurs="0" name="ExternalPaymentOptions" nillable="true" type="zns:ExternalPaymentOptions" />
+					<element minOccurs="0" name="GenerateInvoice" nillable="true" type="xs:boolean" />
+					<element minOccurs="0" name="ProcessPayments" nillable="true" type="xs:boolean" />
+					<element minOccurs="0" name="SubscribeInvoiceProcessingOptions" nillable="true" type="zns:SubscribeInvoiceProcessingOptions" />
+				</sequence>
+			</complexType>			
+			<complexType name="SubscribeInvoiceProcessingOptions">
+			    <sequence>
+			        <element minOccurs="0" name="InvoiceDate" nillable="true" type="dateTime" />
+			        <element minOccurs="0" name="InvoiceProcessingScope" nillable="true" type="xs:string" />
+			        <element minOccurs="0" name="InvoiceTargetDate" nillable="true" type="dateTime" />
+			    </sequence>
+			</complexType>
+			<complexType name="SubscriptionData">
+				<sequence>
+					<element minOccurs="0" name="Subscription" nillable="true" type="ons:Subscription" />
+					<element minOccurs="0" maxOccurs="unbounded" name="RatePlanData" nillable="true" type="zns:RatePlanData" />
+				</sequence>
+			</complexType>
+			<complexType name="RatePlanData">
+				<sequence>
+					<element minOccurs="0" name="RatePlan" nillable="true" type="ons:RatePlan" />
+					<element maxOccurs="unbounded" minOccurs="0" name="RatePlanChargeData" nillable="true" type="zns:RatePlanChargeData" />
+					<element minOccurs="0" maxOccurs="1" name="SubscriptionProductFeatureList" nillable="true" type="zns:SubscriptionProductFeatureList"  />
+				</sequence>
+			</complexType>
+					<complexType name="SubscriptionProductFeatureList">
+						<sequence>
+							<element maxOccurs="100" minOccurs="0" name="SubscriptionProductFeature" nillable="true" type="ons:SubscriptionProductFeature" />
+				</sequence>
+			</complexType>
+				<complexType name="RatePlanChargeData">
+					<sequence>
+						<element minOccurs="0" name="RatePlanCharge" nillable="true" type="ons:RatePlanCharge" />
+						<element maxOccurs="unbounded" minOccurs="0" name="RatePlanChargeTier" nillable="true" type="ons:RatePlanChargeTier" />
+					</sequence>
+				</complexType>
+				<complexType name="ProductRatePlanChargeTierData">
+					<sequence>
+						<element maxOccurs="unbounded" minOccurs="0" name="ProductRatePlanChargeTier" nillable="true" type="ons:ProductRatePlanChargeTier" />
+					</sequence>
+				</complexType>
+				<complexType name="InvoicePaymentData">
+					<sequence>
+						<element maxOccurs="unbounded" minOccurs="0" name="InvoicePayment" nillable="true" type="ons:InvoicePayment" />
+					</sequence>
+				</complexType>
+				<complexType name="RefundInvoicePaymentData">
+					<sequence>
+						<element maxOccurs="unbounded" minOccurs="0" name="RefundInvoicePayment" nillable="true" type="ons:RefundInvoicePayment" />
+					</sequence>
+				</complexType>
+			<complexType name="GatewayOptionData">
+				<sequence>
+					<element maxOccurs="200" minOccurs="0" name="GatewayOption" nillable="true" type="ons:GatewayOption" />
+				</sequence>
+			</complexType>
+				<complexType name="InvoiceData">
+					<sequence>
+						<element minOccurs="0" name="Invoice" nillable="true" type="ons:Invoice" />
+						<element minOccurs="0" maxOccurs="unbounded" name="InvoiceItem" nillable="true" type="ons:InvoiceItem" />
+					</sequence>
+				</complexType>
+				<complexType name="InvoiceResult">
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="Invoice" nillable="true" type="ons:Invoice" />
+					</sequence>
+				</complexType>
+				<complexType name="PreviewOptions">
+					<sequence>
+						<element minOccurs="0" name="EnablePreviewMode" nillable="true" type="boolean" />
+						<element minOccurs="0" name="NumberOfPeriods" nillable="true" type="int" />
+						<element minOccurs="0" name="PreviewThroughTermEnd" nillable="true" type="boolean" />
+					</sequence>
+				</complexType>
+		
+			<complexType name="SubscribeResult">
+				<sequence>
+					<element minOccurs="0" name="AccountId" nillable="true" type="zns:ID" />
+					<element minOccurs="0" name="AccountNumber" nillable="true" type="string" />
+					<element minOccurs="0" maxOccurs="unbounded" name="Errors" nillable="true" type="zns:Error" />
+					<element minOccurs="0" maxOccurs="1" name="GatewayResponse" nillable="true" type="string" />
+					<element minOccurs="0" maxOccurs="1" name="GatewayResponseCode" nillable="true" type="string" />
+					<element minOccurs="0" maxOccurs="unbounded" name="InvoiceData" nillable="true" type="zns:InvoiceData" />
+					<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+					<element minOccurs="0" name="InvoiceNumber" nillable="true" type="string" />
+					<element minOccurs="0" name="InvoiceResult" nillable="true" type="zns:InvoiceResult" />
+					<element minOccurs="0" name="PaymentId" nillable="true" type="zns:ID" />
+					<element minOccurs="0" name="PaymentTransactionNumber" nillable="true" type="string" />
+					<element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+					<element minOccurs="0" name="SubscriptionNumber" nillable="true" type="string" />
+					<element minOccurs="0" maxOccurs="1" name="Success" type="boolean" />
+					<element minOccurs="0" name="TotalMrr" nillable="true" type="decimal" />
+					<element minOccurs="0" name="TotalTcv" nillable="true" type="decimal" />
+				</sequence>
+			</complexType>
+			<complexType name="SaveResult">
+				<sequence>
+					<element minOccurs="0" maxOccurs="unbounded" name="Errors" nillable="true" type="zns:Error" />
+					<element minOccurs="0" maxOccurs="1" name="Id" nillable="true" type="zns:ID" />
+					<element minOccurs="0" maxOccurs="1" name="Success" type="boolean" />
+				</sequence>
+			</complexType>
+			<complexType name="DeleteResult">
+				<sequence>
+					<element name="errors" minOccurs="0" maxOccurs="unbounded" type="zns:Error" nillable="true" />
+					<element name="id" minOccurs="0" maxOccurs="1" type="zns:ID" nillable="true" />
+					<element name="success" minOccurs="0" maxOccurs="1" type="boolean" />
+				</sequence>
+			</complexType>
+				<complexType name="ExecuteResult">
+					<sequence>
+						<element name="Errors" minOccurs="0" maxOccurs="unbounded" type="zns:Error" nillable="true" />
+						<element name="Id" minOccurs="0" maxOccurs="1" type="zns:ID" nillable="true" />
+						<element name="Success" minOccurs="0" maxOccurs="1" type="boolean" />
+					</sequence>
+				</complexType>
+			<simpleType name="QueryLocator">
+				<restriction base="xs:string" />
+			</simpleType>
+			<complexType name="QueryResult">
+				<sequence>
+					<element name="done" type="xs:boolean" />
+					<element name="queryLocator" type="zns:QueryLocator" nillable="true" />
+					<element name="records" type="ons:zObject" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+					<element name="size" type="xs:int" />
+				</sequence>
+			</complexType>
+			<complexType name="Error">
+				<sequence>
+					<element minOccurs="0" name="Code" nillable="true" type="zns:ErrorCode" />
+					<element minOccurs="0" name="Message" nillable="true" type="string" />
+					<element minOccurs="0" name="Field" nillable="true" type="string" />
+				</sequence>
+			</complexType>
+			
+			
+			<simpleType name="ErrorCode">
+				<restriction base="xs:string">
+					<enumeration value="API_DISABLED" />
+					<enumeration value="CANNOT_DELETE" />
+					<enumeration value="CREDIT_CARD_PROCESSING_FAILURE" />
+					<enumeration value="DUPLICATE_VALUE" />
+					<enumeration value="INVALID_FIELD" />
+					<enumeration value="INVALID_LOGIN" />
+					<enumeration value="INVALID_SESSION" />
+					<enumeration value="INVALID_TYPE" />
+					<enumeration value="INVALID_ID" />
+					<enumeration value="INVALID_VALUE" />
+					<enumeration value="INVALID_VERSION" />
+					<enumeration value="LOCK_COMPETITION"  />
+					<enumeration value="MALFORMED_QUERY" />
+					<enumeration value="MAX_RECORDS_EXCEEDED" />
+					<enumeration value="MISSING_REQUIRED_VALUE" />
+					<enumeration value="NO_PERMISSION" />
+					<enumeration value="SERVER_UNAVAILABLE" />
+					<enumeration value="UNKNOWN_ERROR" />
+					<enumeration value="TRANSACTION_FAILED" />
+					<enumeration value="INVALID_TEMPLATE" />
+					<enumeration value="ACCOUNTING_PERIOD_CLOSED" />
+					<enumeration value="BATCH_FAIL_ERROR"/>
+					<enumeration value="PDF_QUERY_ERROR" />
+					<enumeration value="REQUEST_EXCEEDED_LIMIT" />
+					<enumeration value="REQUEST_EXCEEDED_RATE" />
+					<enumeration value="REQUEST_REJECTED" />
+					<enumeration value="TEMPORARY_ERROR"  />
+					<enumeration value="TRANSACTION_TERMINATED"  />
+					<enumeration value="TRANSACTION_TIMEOUT"  />
+				</restriction>
+			</simpleType>
+			<element name="login">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="1" name="username" type="string" />
+						<element minOccurs="0" maxOccurs="1" name="password" type="string" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="loginResponse">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="1" name="result" type="zns:LoginResult" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="subscribe">
+				<complexType>
+					<sequence>
+						<element name="subscribes" minOccurs="0" maxOccurs="unbounded" type="zns:SubscribeRequest" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="subscribeResponse">
+				<complexType>
+					<sequence>
+						<element name="result" minOccurs="0" maxOccurs="unbounded" type="zns:SubscribeResult" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="create">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="zObjects" type="ons:zObject" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="createResponse">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="result" type="zns:SaveResult" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="generate">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="zObjects" type="ons:zObject" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="generateResponse">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="result" type="zns:SaveResult" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="update">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="zObjects" type="ons:zObject" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="updateResponse">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="result" type="zns:SaveResult" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="delete">
+				<complexType>
+					<sequence>
+						<element name="type" type="string" minOccurs="1" maxOccurs="1" />
+						<element name="ids" type="zns:ID" minOccurs="0" maxOccurs="unbounded" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="deleteResponse">
+				<complexType>
+					<sequence>
+						<element name="result" type="zns:DeleteResult" minOccurs="0" maxOccurs="unbounded" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="execute">
+				<complexType>
+					<sequence>
+						<element name="type" type="string" minOccurs="1" maxOccurs="1" />
+						<element name="synchronous" type="boolean" minOccurs="1" maxOccurs="1" />
+						<element name="ids" type="zns:ID" minOccurs="0" maxOccurs="unbounded" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="executeResponse">
+				<complexType>
+					<sequence>
+						<element name="result" type="zns:ExecuteResult" minOccurs="0" maxOccurs="unbounded" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="query">
+				<complexType>
+					<sequence>
+						<element name="queryString" type="xs:string" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="queryResponse">
+				<complexType>
+					<sequence>
+						<element name="result" type="zns:QueryResult" />
+					</sequence>
+				</complexType>
+			</element>
+
+           <element name="queryMore"> 
+                <complexType> 
+                    <sequence> 
+                        <element name="queryLocator" type="zns:QueryLocator"/> 
+                    </sequence> 
+                </complexType> 
+            </element> 
+            <element name="queryMoreResponse"> 
+                <complexType> 
+                    <sequence> 
+                        <element name="result" type="zns:QueryResult"/> 
+                    </sequence> 
+                </complexType> 
+            </element> 
+
+			<element name="SessionHeader">
+				<complexType>
+					<sequence>
+						<element name="session" type="string" />
+					</sequence>
+				</complexType>
+			</element>
+
+            <element name="QueryOptions">
+                <complexType>
+                    <sequence>
+                        <element name="batchSize" type="int" minOccurs="0"/>
+                        <element name="caseSensitive" type="boolean" minOccurs="0" />
+                    </sequence>
+                </complexType>
+            </element>
+
+			<element name="getUserInfoResponse">
+				<complexType>
+					<sequence>
+						<element minOccurs="1" maxOccurs="1" name="TenantId" type="string" />
+						<element minOccurs="1" maxOccurs="1" name="TenantName" type="string" />
+						<element minOccurs="1" maxOccurs="1" name="UserEmail" type="string" />
+						<element minOccurs="1" maxOccurs="1" name="UserFullName" type="string" />
+						<element minOccurs="1" maxOccurs="1" name="UserId" type="string" />
+						<element minOccurs="1" maxOccurs="1" name="Username" type="string" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="getUserInfo">
+				<complexType>
+					<sequence/>
+				</complexType>
+			</element>
+			<element name="DummyHeader">
+				<complexType>
+					<sequence>
+						<element minOccurs="0" name="Account" nillable="true" type="ons:Account" />
+						<element minOccurs="0" name="AccountingCode" nillable="true" type="ons:AccountingCode" />
+						<element minOccurs="0" name="AccountingPeriod" nillable="true" type="ons:AccountingPeriod" />
+						<element minOccurs="0" name="Amendment" nillable="true" type="ons:Amendment" />
+						<element minOccurs="0" name="Invoice" nillable="true" type="ons:Invoice" />
+						<element minOccurs="0" name="InvoiceItem" nillable="true" type="ons:InvoiceItem" />
+						<element minOccurs="0" name="InvoicePayment" nillable="true" type="ons:InvoicePayment" />
+						<element minOccurs="0" name="Import" nillable="true" type="ons:Import" />
+						<element minOccurs="0" name="Payment" nillable="true" type="ons:Payment" />
+						<element minOccurs="0" name="PaymentMethodSnapshot" nillable="true" type="ons:PaymentMethodSnapshot" />
+						<element minOccurs="0" name="Product" nillable="true" type="ons:Product" />
+						<element minOccurs="0" name="Feature" nillable="true" type="ons:Feature" />
+						<element minOccurs="0" name="ProductFeature" nillable="true" type="ons:ProductFeature" />
+						<element minOccurs="0" name="ProductRatePlan" nillable="true" type="ons:ProductRatePlan" />
+						<element minOccurs="0" name="ProductRatePlanCharge" nillable="true" type="ons:ProductRatePlanCharge" />
+						<element minOccurs="0" name="ProductRatePlanChargeTier" nillable="true" type="ons:ProductRatePlanChargeTier" />
+						<element minOccurs="0" name="RatePlan" nillable="true" type="ons:RatePlan" />
+						<element minOccurs="0" name="RatePlanCharge" nillable="true" type="ons:RatePlanCharge" />
+						<element minOccurs="0" name="RatePlanChargeTier" nillable="true" type="ons:RatePlanChargeTier" />
+						<element minOccurs="0" name="Usage" nillable="true" type="ons:Usage" />
+						<element minOccurs="0" name="Refund" nillable="true" type="ons:Refund" />
+						<element minOccurs="0" name="RefundInvoicePayment" nillable="true" type="ons:RefundInvoicePayment" />				
+                        <element minOccurs="0" name="Export" nillable="true" type="ons:Export"  />
+						<element minOccurs="0" name="InvoiceItemAdjustment" nillable="true" type="ons:InvoiceItemAdjustment" />			
+						<element minOccurs="0" name="CommunicationProfile" nillable="true" type="ons:CommunicationProfile" />
+					</sequence>
+				</complexType>
+			</element>
+            	<element name="CallOptions">
+                        <complexType>
+                           <sequence>
+                               <element minOccurs="0" name="useSingleTransaction" nillable="true" type="boolean" />
+                           </sequence>
+                       	</complexType>
+                   	</element>
+				<complexType name="InvoiceProcessingOptions">
+				    <sequence>
+			        	<element minOccurs="0" name="InvoiceDate" nillable="true" type="dateTime" />
+				        <element minOccurs="0" name="InvoiceTargetDate" nillable="true" type="dateTime" />
+				    </sequence>
+				</complexType>
+				<complexType name="AmendOptions" >
+					<sequence>
+						<element minOccurs="0" name="ExternalPaymentOptions" nillable="true" type="zns:ExternalPaymentOptions" />
+						<element minOccurs="0" name="GenerateInvoice" nillable="true" type="xs:boolean" />
+				        <element minOccurs="0" name="InvoiceProcessingOptions" nillable="true" type="zns:InvoiceProcessingOptions" />
+						<element minOccurs="0" name="ProcessPayments" nillable="true" type="xs:boolean" />
+					</sequence>
+				</complexType>
+				<complexType name="AmendRequest">
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="Amendments" nillable="true" type="ons:Amendment" />
+						<element minOccurs="0" name="AmendOptions" nillable="true" type="zns:AmendOptions" />
+						<element minOccurs="0" name="PreviewOptions" nillable="true" type="zns:PreviewOptions" />
+					</sequence>
+				</complexType>
+				<element name="amend">
+					<complexType>
+						<sequence>
+							<element name="requests" minOccurs="0" maxOccurs="unbounded" type="zns:AmendRequest" />
+						</sequence>
+					</complexType>
+				</element>
+				<complexType name="AmendResult">
+					<sequence>
+						<element minOccurs="0" maxOccurs="unbounded" name="AmendmentIds" nillable="true" type="zns:ID" />
+						<element minOccurs="0" maxOccurs="unbounded" name="Errors" nillable="true" type="zns:Error" />
+	                    <element minOccurs="0" maxOccurs="1" name="GatewayResponse" nillable="true" type="string" />
+    					<element minOccurs="0" maxOccurs="1" name="GatewayResponseCode" nillable="true" type="string" />
+						<element minOccurs="0" maxOccurs="unbounded" name="InvoiceDatas" nillable="true" type="zns:InvoiceData" />
+						<element minOccurs="0" name="InvoiceId" nillable="true" type="zns:ID" />
+						<element minOccurs="0" name="PaymentId" nillable="true" type="zns:ID" />
+						<element minOccurs="0" name="PaymentTransactionNumber" nillable="true" type="string" />
+						<element minOccurs="0" name="SubscriptionId" nillable="true" type="zns:ID" />
+						<element minOccurs="0" maxOccurs="1" name="Success" type="boolean" />
+						<element minOccurs="0" name="TotalDeltaMrr" nillable="true" type="decimal" />
+						<element minOccurs="0" name="TotalDeltaTcv" nillable="true" type="decimal" />
+					</sequence>
+				</complexType>
+				<element name="amendResponse">
+					<complexType>
+						<sequence>
+							<element name="results" minOccurs="0" maxOccurs="unbounded" type="zns:AmendResult" />
+						</sequence>
+					</complexType>
+				</element>
+				<complexType name="ExternalPaymentOptions">
+					<sequence>
+						<element minOccurs="0" name="Amount" nillable="true" type="decimal"/>
+						<element minOccurs="0" name="EffectiveDate" nillable="true" type="dateTime" />
+						<element minOccurs="0" name="GatewayOrderId" nillable="true" type="string"/>
+						<element minOccurs="0" name="PaymentMethodId" nillable="true" type="zns:ID" />
+						<element minOccurs="0" name="ReferenceId" nillable="true" type="xs:string" />
+					</sequence>
+				</complexType>
+			
+
+		</schema>
+		<schema attributeFormDefault="qualified" elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://fault.api.zuora.com/">
+		    <import namespace="http://api.zuora.com/" />
+			<complexType name="ApiFault">
+				<sequence>
+					<element minOccurs="0" name="FaultCode" nillable="true" type="zns:ErrorCode" />
+					<element minOccurs="0" name="FaultMessage" nillable="true" type="string" />
+				</sequence>
+			</complexType>
+			<element name="fault" type="fns:ApiFault" />
+			<complexType name="LoginFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="LoginFault" type="fns:LoginFault" />
+			<complexType name="InvalidTypeFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="InvalidTypeFault" type="fns:InvalidTypeFault" />
+			<complexType name="InvalidValueFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="InvalidValueFault" type="fns:InvalidValueFault" />
+			<complexType name="MalformedQueryFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="MalformedQueryFault" type="fns:MalformedQueryFault" />
+			<complexType name="InvalidQueryLocatorFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="InvalidQueryLocatorFault" type="fns:InvalidQueryLocatorFault" />
+			<complexType name="UnexpectedErrorFault">
+				<complexContent>
+					<extension base="fns:ApiFault" />
+				</complexContent>
+			</complexType>
+			<element name="UnexpectedErrorFault" type="fns:UnexpectedErrorFault" />
+		</schema>
+		
+	</types>
+	<message name="ApiFault">
+		<part name="fault" element="fns:fault" />
+	</message>
+	<message name="LoginFault">
+		<part name="fault" element="fns:LoginFault" />
+	</message>
+	<message name="InvalidTypeFault">
+		<part name="fault" element="fns:InvalidTypeFault" />
+	</message>
+	<message name="InvalidValueFault">
+		<part name="fault" element="fns:InvalidValueFault" />
+	</message>
+	<message name="MalformedQueryFault">
+		<part name="fault" element="fns:MalformedQueryFault" />
+	</message>
+	<message name="InvalidQueryLocatorFault">
+		<part name="fault" element="fns:InvalidQueryLocatorFault" />
+	</message>
+	<message name="UnexpectedErrorFault">
+		<part name="fault" element="fns:UnexpectedErrorFault" />
+	</message>
+	<message name="loginRequest">
+		<part name="parameters" element="zns:login" />
+	</message>
+	<message name="loginResponse">
+		<part name="parameters" element="zns:loginResponse" />
+	</message>
+	<message name="subscribeRequest">
+		<part name="parameters" element="zns:subscribe" />
+	</message>
+	<message name="subscribeResponse">
+		<part name="parameters" element="zns:subscribeResponse" />
+	</message>
+	<message name="createRequest">
+		<part name="parameters" element="zns:create" />
+	</message>
+	<message name="createResponse">
+		<part name="parameters" element="zns:createResponse" />
+	</message>
+	<message name="generateRequest">
+		<part name="parameters" element="zns:generate" />
+	</message>
+	<message name="generateResponse">
+		<part name="parameters" element="zns:generateResponse" />
+	</message>
+	<message name="updateRequest">
+		<part name="parameters" element="zns:update" />
+	</message>
+	<message name="updateResponse">
+		<part name="parameters" element="zns:updateResponse" />
+	</message>
+	<message name="deleteRequest">
+		<part name="parameters" element="zns:delete" />
+	</message>
+	<message name="deleteResponse">
+		<part name="parameters" element="zns:deleteResponse" />
+	</message>
+	<message name="executeRequest">
+		<part name="parameters" element="zns:execute" />
+	</message>
+	<message name="executeResponse">
+		<part name="parameters" element="zns:executeResponse" />
+	</message>
+	<message name="queryRequest">
+		<part name="parameters" element="zns:query" />
+	</message>
+	<message name="queryResponse">
+		<part name="parameters" element="zns:queryResponse" />
+	</message>
+
+	    <message name="queryMoreRequest"> 
+	        <part element="zns:queryMore" name="parameters"/> 
+	    </message> 
+	    <message name="queryMoreResponse"> 
+	        <part element="zns:queryMoreResponse" name="parameters"/> 
+	    </message> 
+
+	<message name="Header">
+		<part name="CallOptions" element="zns:CallOptions" />
+		<part name="QueryOptions" element="zns:QueryOptions" />
+		<part name="SessionHeader" element="zns:SessionHeader" />
+	</message>
+	<message name="getUserInfo">
+		<part name="getUserInfo" element="zns:getUserInfo"/>
+	</message>
+	<message name="getUserInfoResponse">
+		<part name="parameters" element="zns:getUserInfoResponse"/>
+	</message>
+		<message name="amendRequest">
+			<part name="parameters" element="zns:amend"/>
+		</message>
+		<message name="amendResponse">
+			<part name="parameters" element="zns:amendResponse"/>
+		</message>
+
+	
+	<portType name="Soap">
+		<operation name="login">
+			<input message="zns:loginRequest" />
+			<output message="zns:loginResponse" />
+			<fault message="zns:LoginFault" name="LoginFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+		<operation name="subscribe">
+			<input message="zns:subscribeRequest" />
+			<output message="zns:subscribeResponse" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+		<operation name="create">
+			<input message="zns:createRequest" />
+			<output message="zns:createResponse" />
+			<fault message="zns:InvalidTypeFault" name="InvalidTypeFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+		<operation name="generate">
+			<input message="zns:generateRequest" />
+			<output message="zns:generateResponse" />
+			<fault message="zns:InvalidTypeFault" name="InvalidTypeFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+		<operation name="update">
+			<input message="zns:updateRequest" />
+			<output message="zns:updateResponse" />
+			<fault message="zns:InvalidTypeFault" name="InvalidTypeFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+		<operation name="delete">
+			<input message="zns:deleteRequest" />
+			<output message="zns:deleteResponse" />
+			<fault message="zns:InvalidTypeFault" name="InvalidTypeFault" />
+			<fault message="zns:InvalidValueFault" name="InvalidValueFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+			<operation name="execute">
+				<input message="zns:executeRequest" />
+				<output message="zns:executeResponse" />
+				<fault message="zns:InvalidTypeFault" name="InvalidTypeFault" />
+				<fault message="zns:InvalidValueFault" name="InvalidValueFault" />
+				<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+			</operation>
+		<operation name="query">
+			<input message="zns:queryRequest" />
+			<output message="zns:queryResponse" />
+			<fault message="zns:MalformedQueryFault" name="MalformedQueryFault" />
+			<fault message="zns:InvalidQueryLocatorFault" name="InvalidQueryLocatorFault" />
+			<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault" />
+		</operation>
+
+        <operation name="queryMore"> 
+            <documentation>Gets the next batch of sObjects from a query</documentation> 
+            <input  message="zns:queryMoreRequest"/> 
+            <output message="zns:queryMoreResponse"/> 
+            <fault  message="zns:InvalidQueryLocatorFault" name="InvalidQueryLocatorFault"/> 
+            <fault  message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault"/> 
+        </operation> 
+
+        <operation name="getUserInfo">
+        	<input message="zns:getUserInfo"/>
+        	<output message="zns:getUserInfoResponse"/>
+        	<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+    	<operation name="amend">
+        	<input message="zns:amendRequest"/>
+        	<output message="zns:amendResponse"/>
+        	<fault message="zns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+	</portType>
+	<binding name="SoapBinding" type="zns:Soap">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<operation name="login">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="LoginFault">
+				<soap:fault name="LoginFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+		<operation name="subscribe">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+		<operation name="create">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="CallOptions" />
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="InvalidTypeFault">
+				<soap:fault name="InvalidTypeFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+		<operation name="generate">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="InvalidTypeFault">
+				<soap:fault name="InvalidTypeFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+		<operation name="update">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="InvalidTypeFault">
+				<soap:fault name="InvalidTypeFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+		<operation name="query">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="QueryOptions"  />
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="MalformedQueryFault">
+				<soap:fault name="MalformedQueryFault" use="literal" />
+			</fault>
+			<fault name="InvalidQueryLocatorFault">
+				<soap:fault name="InvalidQueryLocatorFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+
+        <operation name="queryMore"> 
+            <soap:operation soapAction=""/> 
+            <input> 
+				<soap:header use="literal" message="zns:Header" part="QueryOptions" />
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+            </input> 
+            <output> 
+                <soap:body use="literal"/> 
+            </output> 
+            <fault name="InvalidQueryLocatorFault"> 
+                <soap:fault name="InvalidQueryLocatorFault" use="literal"/> 
+            </fault> 
+            <fault name="UnexpectedErrorFault"> 
+                <soap:fault name="UnexpectedErrorFault" use="literal"/> 
+            </fault> 
+        </operation>
+
+		<operation name="delete">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="InvalidTypeFault">
+				<soap:fault name="InvalidTypeFault" use="literal" />
+			</fault>
+			<fault name="InvalidValueFault">
+				<soap:fault name="InvalidValueFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+        <operation name="getUserInfo">
+			<soap:operation soapAction=""/>
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal"/>
+			</input>
+			<output>
+				<soap:body use="literal"/>
+			</output>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal"/>
+			</fault>
+        </operation>
+    	<operation name="amend">
+			<soap:operation soapAction=""/>
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal"/>
+			</input>
+			<output>
+				<soap:body use="literal"/>
+			</output>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal"/>
+			</fault>
+        </operation>
+    	<operation name="execute">
+			<soap:operation soapAction="" />
+			<input>
+				<soap:header use="literal" message="zns:Header" part="SessionHeader" />
+				<soap:body use="literal" />
+			</input>
+			<output>
+				<soap:body use="literal" />
+			</output>
+			<fault name="InvalidTypeFault">
+				<soap:fault name="InvalidTypeFault" use="literal" />
+			</fault>
+			<fault name="InvalidValueFault">
+				<soap:fault name="InvalidValueFault" use="literal" />
+			</fault>
+			<fault name="UnexpectedErrorFault">
+				<soap:fault name="UnexpectedErrorFault" use="literal" />
+			</fault>
+		</operation>
+	</binding>
+	<service name="ZuoraService">
+		<port name="Soap" binding="zns:SoapBinding">
+			<soap:address location="https://www.zuora.com/apps/services/a/64.0" />
+		</port>
+	</service>
+</definitions>


### PR DESCRIPTION
1. Added the last version of zuora WSDL files (production and staging ones) which is a.64
2. Normalized the use of snake case for RestClient base_url attribute (before that we were forced to have two keys in zuora settings' dict : baseUrl and base_url, with the same value).
3. Small detail : made a proxy method with a proper zuora function name for subscriptions in REST client. The concerned method is get_subscriptions_by_key which returns just one subscription (see title of this : https://knowledgecenter.zuora.com/D_REST_API/B_REST_API_reference/Subscriptions/3_DRAFT_REST_Get_subscription_by_key)
